### PR TITLE
[MRG] Pass parallelization back-end as an argument

### DIFF
--- a/fmralign/tests/test_pairwise_alignment.py
+++ b/fmralign/tests/test_pairwise_alignment.py
@@ -21,7 +21,8 @@ def test_pairwise_identity():
                  {'alignment_method': 'identity', 'n_pieces': 3,
                      'n_bags': 3, 'mask': mask_img, 'n_jobs': 2},
                  {'alignment_method': 'identity', 'n_pieces': 3,
-                     'n_bags': 2, 'mask': mask_img, 'n_jobs': 2, 'parallel_backend': 'multiprocessing'}
+                     'n_bags': 2, 'mask': mask_img, 'n_jobs': 2,
+                     'parallel_backend': 'multiprocessing'}
                  ]
     for args in args_list:
         algo = PairwiseAlignment(**args)

--- a/fmralign/tests/test_pairwise_alignment.py
+++ b/fmralign/tests/test_pairwise_alignment.py
@@ -17,9 +17,11 @@ def test_pairwise_identity():
                  {'alignment_method': 'identity', 'n_pieces': 3,
                   'mask': mask_img},
                  {'alignment_method': 'identity', 'n_pieces': 3,
-                     'n_bags': 10, 'mask': mask_img},
+                     'n_bags': 4, 'mask': mask_img},
                  {'alignment_method': 'identity', 'n_pieces': 3,
-                     'n_bags': 10, 'mask': mask_img, 'n_jobs': 2}
+                     'n_bags': 3, 'mask': mask_img, 'n_jobs': 2},
+                 {'alignment_method': 'identity', 'n_pieces': 3,
+                     'n_bags': 2, 'mask': mask_img, 'n_jobs': 2, 'parallel_backend': 'multiprocessing'}
                  ]
     for args in args_list:
         algo = PairwiseAlignment(**args)


### PR DESCRIPTION
Convenience change to be able to run the library in different types of clusters (here dask for margaret). Default behavior is not changed but more flexibility is added