### PR TITLE
[doc] improve error when calling unrecognized alignment method

### DIFF
--- a/fmralign/pairwise_alignment.py
+++ b/fmralign/pairwise_alignment.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 """ Module for pairwise functional alignment
 """
-
-import copy
 import numpy as np
-from time import time
 
 from sklearn.base import BaseEstimator, TransformerMixin
 from joblib import Parallel, delayed
@@ -101,7 +98,12 @@ def fit_one_piece(X_i, Y_i, alignment_method):
                                        OptimalTransportAlignment,
                                        DiagonalAlignment)):
         alignment_algo = clone(alignment_method)
-    alignment_algo.fit(X_i, Y_i)
+    try:
+        alignment_algo.fit(X_i, Y_i)
+    except UnboundLocalError:
+        warn = "Unrecognized alignment method {}.".format(alignment_method) + \
+               " Please provide a recognized alignment method."
+        raise NotImplementedError(warn)
 
     return alignment_algo
 

--- a/fmralign/tests/test_pairwise_alignment.py
+++ b/fmralign/tests/test_pairwise_alignment.py
@@ -1,14 +1,19 @@
 # -*- coding: utf-8 -*-
 
-import numpy as np
-import nibabel
-from sklearn.utils.testing import assert_array_almost_equal, assert_greater
+import pytest
+from sklearn.utils.testing import assert_greater
 from nilearn.input_data import NiftiMasker
 from fmralign.pairwise_alignment import PairwiseAlignment
-from fmralign.tests.utils import assert_algo_transform_almost_exactly, \
-    random_niimg, assert_model_align_better_than_identity, \
-    zero_mean_coefficient_determination
-from fmralign.alignment_methods import optimal_permutation, Hungarian
+from fmralign.tests.utils import (assert_algo_transform_almost_exactly,
+                                  zero_mean_coefficient_determination,
+                                  random_niimg)
+
+
+def test_unsupported_alignment():
+    mask_img = random_niimg((8, 7, 6, 10))
+    args = {'alignment_method': 'scaled_procrustes', 'mask': mask_img}
+    with pytest.raises(NotImplementedError):
+        PairwiseAlignment(**args)
 
 
 def test_pairwise_identity():
@@ -40,8 +45,8 @@ def test_models_against_identity():
                              'optimal_transport', 'diagonal']:
         for clustering in ["kmeans", "hierarchical_kmeans"]:
             algo = PairwiseAlignment(
-                alignment_method=alignment_method, mask=masker, clustering=clustering,
-                n_pieces=2, n_bags=1, n_jobs=1)
+                alignment_method=alignment_method, mask=masker,
+                clustering=clustering, n_pieces=2, n_bags=1, n_jobs=1)
             algo.fit(img1, img2)
             im_test = algo.transform(img1)
             algo_score = zero_mean_coefficient_determination(ground_truth,

--- a/fmralign/tests/test_pairwise_alignment.py
+++ b/fmralign/tests/test_pairwise_alignment.py
@@ -10,10 +10,12 @@ from fmralign.tests.utils import (assert_algo_transform_almost_exactly,
 
 
 def test_unsupported_alignment():
-    mask_img = random_niimg((8, 7, 6, 10))
+    img1, mask_img = random_niimg((8, 7, 6, 10))
+    img2, _ = random_niimg((7, 6, 8, 5))
     args = {'alignment_method': 'scaled_procrustes', 'mask': mask_img}
+    algo = PairwiseAlignment(**args)
     with pytest.raises(NotImplementedError):
-        PairwiseAlignment(**args)
+        algo.fit(img1, img2)
 
 
 def test_pairwise_identity():


### PR DESCRIPTION
Currently, calling an unrecognized alignment method yields `UnboundLocalError`. Since I keep accidentally calling `scaled_procrustes` instead of `scaled_orthogonal`, I thought it might make sense to provide a more interpretable error message !

Also lightly lints for some unused imports.