### PR TITLE
[fix] reduce warnings

### DIFF
--- a/fmralign/_utils.py
+++ b/fmralign/_utils.py
@@ -1,18 +1,14 @@
 import numpy as np
+import nibabel as nib
+from packaging import version
 from scipy.stats import pearsonr
-from nilearn.regions.parcellations import Parcellations
+from sklearn.cluster import MiniBatchKMeans
+
+import nilearn
 from nilearn.image import smooth_img
+from nilearn.regions.parcellations import Parcellations
 from nilearn.masking import _apply_mask_fmri
 from nilearn._utils.niimg_conversions import _check_same_fov
-import nilearn
-import nibabel
-from packaging import version
-import numpy as np
-from sklearn.cluster import MiniBatchKMeans
-from sklearn.base import TransformerMixin, ClusterMixin
-from sklearn.base import BaseEstimator
-from sklearn.utils import check_array
-from sklearn.utils.validation import check_is_fitted
 
 
 def piecewise_transform(labels, estimators, X):
@@ -145,9 +141,9 @@ def _make_parcellation(imgs, clustering, n_pieces, masker, smoothing_fwhm=5, ver
     labels : list of ints (len n_features)
         Parcellation of features in clusters
     """
-    print(clustering)
-    if type(clustering) == nibabel.nifti1.Nifti1Image:
-        # check image makes suitable labels, this will return friendly error message if needed
+    if type(clustering) == nib.nifti1.Nifti1Image:
+        # check image makes suitable labels,
+        # this will return friendly error message if needed
         _check_same_fov(masker.mask_img_, clustering)
         labels_img = clustering
     elif clustering == "hierarchical_kmeans":

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -6,6 +6,7 @@ import scipy
 from scipy.spatial.distance import cdist
 from scipy import linalg
 from scipy.sparse import diags
+import sklearn
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.linear_assignment_ import linear_assignment
 from sklearn.metrics.pairwise import pairwise_distances
@@ -267,7 +268,9 @@ class RidgeAlignment(Alignment):
             target data
         """
         self.R = RidgeCV(alphas=self.alphas, fit_intercept=True,
-                         normalize=False, scoring=None, cv=self.cv)
+                         normalize=False,
+                         scoring=sklearn.metrics.SCORERS['r2'],
+                         cv=self.cv)
         self.R.fit(X, Y)
         return self
 

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -8,7 +8,7 @@ from scipy import linalg
 from scipy.sparse import diags
 import sklearn
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.linear_assignment_ import linear_assignment
+from scipy.optimize import linear_sum_assignment
 from sklearn.metrics.pairwise import pairwise_distances
 from sklearn.linear_model import RidgeCV
 from joblib import Parallel, delayed
@@ -83,7 +83,8 @@ def optimal_permutation(X, Y):
         transformation matrix
     """
     dist = pairwise_distances(X.T, Y.T)
-    u = linear_assignment(dist)
+    u = linear_sum_assignment(dist)
+    u = np.array(list(zip(*u)))
     permutation = scipy.sparse.csr_matrix(
         (np.ones(X.shape[1]), (u[:, 0], u[:, 1]))).T
     return permutation

--- a/fmralign/pairwise_alignment.py
+++ b/fmralign/pairwise_alignment.py
@@ -7,8 +7,7 @@ import numpy as np
 from time import time
 
 from sklearn.base import BaseEstimator, TransformerMixin
-from joblib import Parallel, delayed
-from sklearn.externals.joblib import Memory
+from joblib import (delayed, Memory, Parallel)
 from sklearn.model_selection import ShuffleSplit
 from sklearn.base import clone
 from nilearn.input_data.masker_validation import check_embedded_nifti_masker

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -7,8 +7,7 @@ prediction of new subjects unseen images
 
 from sklearn.base import BaseEstimator, TransformerMixin
 import numpy as np
-from joblib import Parallel, delayed
-from sklearn.externals.joblib import Memory
+from joblib import (delayed, Memory, Parallel)
 from nilearn.image import index_img, concat_imgs, load_img
 from nilearn.input_data.masker_validation import check_embedded_nifti_masker
 from fmralign.pairwise_alignment import PairwiseAlignment

--- a/fmralign/version.py
+++ b/fmralign/version.py
@@ -54,6 +54,10 @@ REQUIRED_MODULE_METADATA = (
         'min_version': '3.1.1',
         'required_at_installation': True,
         'install_info': _FMRALIGN_INSTALL_MSG}),
+    ('packaging', {
+        'min_version': '20.0',
+        'required_at_installation': True,
+        'install_info': _FMRALIGN_INSTALL_MSG}),
     ('POT', {
         'min_version': '0.5.0',
         'required_at_installation': False,


### PR DESCRIPTION
Right now importing several modules  such as `pairwise_alignment` or `template_alignment` yield `FutureWarning`s. Similarly, running `RidgeCV` alignment yields the following `FutureWarning`:

> /srv/conda/envs/notebook/lib/python3.7/site-packages/sklearn/base.py:434: FutureWarning: The default value of multioutput (not exposed in score method) will change from 'variance_weighted' to 'uniform_average' in 0.23 to keep consistent with 'metrics.r2_score'. To specify the default value manually and avoid the warning, please either call 'metrics.r2_score' directly or make a custom scorer with 'metrics.make_scorer' (the built-in scorer 'r2' uses multioutput='uniform_average').

Unfortunately, this appears on each iteration making outputs harder to find. This PR patches these methods such that future warnings are not raised.

LMK what you think ! :smile_cat: 