### PR TITLE
fix: update get_data to get_fdata method

### DIFF
--- a/examples/plot_alignment_methods_benchmark.py
+++ b/examples/plot_alignment_methods_benchmark.py
@@ -46,7 +46,7 @@ atlas = load_img(atlas_yeo_2011.thick_7)
 
 # Select visual cortex, create a mask and resample it to the right resolution
 
-mask_visual = new_img_like(atlas, atlas.get_data() == 1)
+mask_visual = new_img_like(atlas, atlas.get_fdata() == 1)
 resampled_mask_visual = resample_to_img(
     mask_visual, mask, interpolation="nearest")
 
@@ -103,7 +103,7 @@ target_test = df[df.subject == 'sub-02'][df.acquisition == 'pa'].path.values
 #
 
 import numpy as np
-n_voxels = roi_masker.mask_img_.get_data().sum()
+n_voxels = roi_masker.mask_img_.get_fdata().sum()
 print("The chosen region of interest contains {} voxels".format(n_voxels))
 n_pieces = int(np.round(n_voxels / 200))
 print("We will cluster them in {} regions".format(n_pieces))

--- a/examples/plot_pairwise_roi_alignment.py
+++ b/examples/plot_pairwise_roi_alignment.py
@@ -50,7 +50,7 @@ atlas = load_img(atlas_yeo)
 
 # Select visual cortex, create a mask and resample it to the right resolution
 
-mask_visual = new_img_like(atlas, atlas.get_data() == 1)
+mask_visual = new_img_like(atlas, atlas.get_fdata() == 1)
 resampled_mask_visual = resample_to_img(
     mask_visual, mask, interpolation="nearest")
 

--- a/fmralign/pairwise_alignment.py
+++ b/fmralign/pairwise_alignment.py
@@ -149,7 +149,7 @@ def fit_one_parcellation(X_, Y_, alignment_method, masker, n_pieces,
                                     n_pieces, masker, verbose=verbose)
     else:
         labels = np.ones(
-            int(masker.mask_img_.get_data().sum()), dtype=np.int8)
+            int(masker.mask_img_.get_fdata().sum()), dtype=np.int8)
 
     fit = Parallel(n_jobs, prefer="threads", verbose=verbose)(
         delayed(fit_one_piece)(

--- a/fmralign/tests/test_template_alignment.py
+++ b/fmralign/tests/test_template_alignment.py
@@ -27,14 +27,14 @@ def test_template_identity():
     # test euclidian mean function
     euclidian_template = _rescaled_euclidean_mean(subs, masker)
     assert_array_almost_equal(
-        ref_template.get_data(), euclidian_template.get_data())
+        ref_template.get_fdata(), euclidian_template.get_fdata())
 
     # test different fit() accept list of list of 3D Niimgs as input.
     algo = TemplateAlignment(alignment_method='identity', mask=masker)
     algo.fit([n * [im]] * 3)
     # test template
     assert_array_almost_equal(
-        sub_1.get_data(), algo.template.get_data())
+        sub_1.get_fdata(), algo.template.get_fdata())
 
     # test fit() transform() with 4D Niimgs input for several params set
     args_list = [{'alignment_method': 'identity', 'mask': masker},
@@ -50,13 +50,13 @@ def test_template_identity():
         algo.fit(subs)
         # test template
         assert_array_almost_equal(
-            ref_template.get_data(), algo.template.get_data())
+            ref_template.get_fdata(), algo.template.get_fdata())
         predicted_imgs = algo.transform(
             [index_img(sub_1, range(8))], train_index=range(8),
             test_index=range(8, 10))
         ground_truth = index_img(ref_template, range(8, 10))
         assert_array_almost_equal(
-            ground_truth.get_data(), predicted_imgs[0].get_data())
+            ground_truth.get_fdata(), predicted_imgs[0].get_fdata())
 
     # test transform() with wrong indexes length or content (on previous fitted algo)
     train_inds, test_inds = [[0, 1], [1, 10],

--- a/source/functional_alignment/fmralign_pipeline.rst
+++ b/source/functional_alignment/fmralign_pipeline.rst
@@ -118,7 +118,7 @@ Extract a mask for the visual cortex from Yeo Atlas
 
 Select visual cortex, create a mask and resample it to the right resolution
 
->>> mask_visual = new_img_like(atlas, atlas.get_data() == 1)
+>>> mask_visual = new_img_like(atlas, atlas.get_fdata() == 1)
 >>> resampled_mask_visual = resample_to_img(
     mask_visual, mask, interpolation="nearest")
 
@@ -169,7 +169,7 @@ To proceed with alignment we use the class PairwiseAlignment with the masker we 
 
 First we choose a suitable number of regions such that each regions is approximately 200 voxels wide.
 
->>> n_voxels = roi_masker.mask_img_.get_data().sum()
+>>> n_voxels = roi_masker.mask_img_.get_fdata().sum()
 >>> n_pieces = np.round(n_voxels / 200)
 
 Then for each method we define the estimator, fit it, and predict new image. We then plot


### PR DESCRIPTION
Follow-up on #43 

Updates `.get_data()` calls to `.get_fdata()` pending upcoming Nibabel deprecation. 