### PR TITLE
Updates for newer ott-jax interface

### DIFF
--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 import scipy
-from scipy.spatial.distance import cdist
 from scipy import linalg
 from scipy.sparse import diags
 import sklearn
@@ -434,14 +433,15 @@ class OptimalTransportAlignment(Alignment):
             '''
         from ott.geometry import geometry
         from ott.solvers.linear import sinkhorn
+        from ott.geometry.costs import Euclidean
         from ott.problems.linear import linear_problem
 
-        cost_matrix = cdist(X.T, Y.T, metric=self.metric)
+        cost_matrix = Euclidean().all_pairs(x=X.T, y=Y.T)
         geom = geometry.Geometry(cost_matrix=cost_matrix, epsilon=self.reg)
-        problem = linear_problem.LinearProblem(geom, X.T, Y.T)
+        problem = linear_problem.LinearProblem(geom)
 
         solver = sinkhorn.Sinkhorn(
-            geom, max_iterations=self.max_iter, threshold=self.tol, jit=True)
+            geom, max_iterations=self.max_iter, threshold=self.tol)
         self.R = solver(problem).matrix
         return self
 

--- a/fmralign/version.py
+++ b/fmralign/version.py
@@ -58,6 +58,10 @@ REQUIRED_MODULE_METADATA = (
         'min_version': '20.0',
         'required_at_installation': True,
         'install_info': _FMRALIGN_INSTALL_MSG}),
+    ('ott-jax', {
+        'min_version': '0.3.0',
+        'required_at_installation': True,
+        'install_info': _FMRALIGN_INSTALL_MSG})
     ('POT', {
         'min_version': '0.5.0',
         'required_at_installation': False,

--- a/fmralign/version.py
+++ b/fmralign/version.py
@@ -61,7 +61,7 @@ REQUIRED_MODULE_METADATA = (
     ('ott-jax', {
         'min_version': '0.3.0',
         'required_at_installation': True,
-        'install_info': _FMRALIGN_INSTALL_MSG})
+        'install_info': _FMRALIGN_INSTALL_MSG}),
     ('POT', {
         'min_version': '0.5.0',
         'required_at_installation': False,


### PR DESCRIPTION
The current codebase uses an older version of OTT-JAX that relies on a deprecated version of JAX ; it is no longer accessible on PyPi and therefore difficult to reproducibly build.

_(NB : I do have a Dockerfile which can be used to this effect ; happy to share here though I think it might be better placed on the fmralign-benchmark repo)._

These changes bump to a more recent version of OTT-JAX and update internal calls accordingly.
I'd like to test a bit more against our older results before committing, but LMK if you have any feedback !