### PR TITLE
[Bugfix] Remove deprecated normalize option in RidgeCV

### DIFF
--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -275,7 +275,6 @@ class RidgeAlignment(Alignment):
             target data
         """
         self.R = RidgeCV(alphas=self.alphas, fit_intercept=True,
-                         normalize=False,
                          scoring=sklearn.metrics.SCORERS['r2'],
                          cv=self.cv)
         self.R.fit(X, Y)


### PR DESCRIPTION
The ``normalize`` option in ``sklearn.linear_model.RidgeCV`` has been removed in newer versions of scikit learn. This small PR fixes the issue.