### PR TITLE
[INFRA] Untrack nilearn, set 10.2 as minimum version

### DIFF
--- a/fmralign/_utils.py
+++ b/fmralign/_utils.py
@@ -4,9 +4,9 @@ import warnings
 
 import nibabel as nib
 import numpy as np
-from nilearn._utils.niimg_conversions import check_same_fov
+from nilearn._utils.niimg_conversions import _check_same_fov
 from nilearn.image import index_img, new_img_like, smooth_img
-from nilearn.masking import apply_mask_fmri, intersect_masks
+from nilearn.masking import _apply_mask_fmri, intersect_masks
 from nilearn.regions.parcellations import Parcellations
 
 
@@ -107,8 +107,8 @@ def _make_parcellation(
     """
     # check if clustering is provided
     if isinstance(clustering, nib.nifti1.Nifti1Image) or os.path.isfile(clustering):
-        check_same_fov(masker.mask_img_, clustering)
-        labels = apply_mask_fmri(clustering, masker.mask_img_).astype(int)
+        _check_same_fov(masker.mask_img_, clustering)
+        labels = _apply_mask_fmri(clustering, masker.mask_img_).astype(int)
 
     # otherwise check it's needed, if not return 1 everywhere
     elif n_pieces == 1:
@@ -140,7 +140,9 @@ def _make_parcellation(
             )
             err.args += (errmsg,)
             raise err
-        labels = apply_mask_fmri(parcellation.labels_img_, masker.mask_img_).astype(int)
+        labels = _apply_mask_fmri(parcellation.labels_img_, masker.mask_img_).astype(
+            int
+        )
 
     if verbose > 0:
         unique_labels, counts = np.unique(labels, return_counts=True)

--- a/fmralign/fetch_example_data.py
+++ b/fmralign/fetch_example_data.py
@@ -2,7 +2,7 @@
 import os
 
 import pandas as pd
-from nilearn.datasets._utils import fetch_files, get_dataset_dir
+from nilearn.datasets.utils import _fetch_files, _get_dataset_dir
 
 
 def fetch_ibc_subjects_contrasts(subjects, data_dir=None, verbose=1):
@@ -34,7 +34,7 @@ def fetch_ibc_subjects_contrasts(subjects, data_dir=None, verbose=1):
         Path to the mask to be used on the data
     Notes
     ------
-    This function is a caller to nilearn.datasets._utils.fetch_files in order
+    This function is a caller to nilearn.datasets.utils._fetch_files in order
     to simplify examples reading and understanding for fmralign.
     See Also
     ---------
@@ -45,11 +45,11 @@ def fetch_ibc_subjects_contrasts(subjects, data_dir=None, verbose=1):
     if subjects == "all":
         subjects = ["sub-{i:02d}" for i in [1, 2, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15]]
     dataset_name = "ibc"
-    data_dir = get_dataset_dir(dataset_name, data_dir=data_dir, verbose=verbose)
+    data_dir = _get_dataset_dir(dataset_name, data_dir=data_dir, verbose=verbose)
 
     # download or retrieve metadatas, put it in a dataframe,
     # list all condition and specify path to the right directory
-    metadata_path = fetch_files(
+    metadata_path = _fetch_files(
         data_dir,
         [
             (
@@ -67,7 +67,7 @@ def fetch_ibc_subjects_contrasts(subjects, data_dir=None, verbose=1):
     metadata_df = metadata_df[metadata_df.subject.isin(subjects)]
 
     # download / retrieve mask niimg and find its path
-    mask = fetch_files(
+    mask = _fetch_files(
         data_dir,
         [("gm_mask_3mm.nii.gz", "https://osf.io/yvju3/download", {"uncompress": True})],
         verbose=verbose,
@@ -106,5 +106,5 @@ def fetch_ibc_subjects_contrasts(subjects, data_dir=None, verbose=1):
                 for condition in conditions
             ]
         )
-        files.append(fetch_files(data_dir, filenames, verbose=verbose))
+        files.append(_fetch_files(data_dir, filenames, verbose=verbose))
     return files, metadata_df, mask

--- a/fmralign/pairwise_alignment.py
+++ b/fmralign/pairwise_alignment.py
@@ -8,7 +8,7 @@ import nibabel as nib
 import numpy as np
 from joblib import Memory, Parallel, delayed
 from nilearn.image import concat_imgs, load_img
-from nilearn._utils.masker_validation import check_embedded_masker
+from nilearn.maskers._masker_validation import _check_embedded_nifti_masker
 from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.model_selection import ShuffleSplit
 
@@ -313,7 +313,7 @@ class PairwiseAlignment(BaseEstimator, TransformerMixin):
         -------
         self
         """
-        self.masker_ = check_embedded_masker(self)
+        self.masker_ = _check_embedded_nifti_masker(self)
         self.masker_.n_jobs = self.n_jobs
 
         if self.masker_.mask_img is None:
@@ -330,7 +330,7 @@ class PairwiseAlignment(BaseEstimator, TransformerMixin):
                     self.clustering, self.masker_.mask_img
                 )
                 self.mask = reduced_mask
-                self.masker_ = check_embedded_masker(self)
+                self.masker_ = _check_embedded_nifti_masker(self)
                 self.masker_.n_jobs = self.n_jobs
                 self.masker_.fit()
                 warnings.warn(

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -9,7 +9,7 @@ Uses functional alignment on Niimgs and predicts new subjects' unseen images.
 import numpy as np
 from joblib import Memory, Parallel, delayed
 from nilearn.image import concat_imgs, index_img, load_img
-from nilearn._utils.masker_validation import check_embedded_masker
+from nilearn.maskers._masker_validation import _check_embedded_nifti_masker
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from fmralign.pairwise_alignment import PairwiseAlignment
@@ -388,7 +388,7 @@ class TemplateAlignment(BaseEstimator, TransformerMixin):
             if isinstance(imgs[0], (list, np.ndarray)):
                 imgs = [concat_imgs(img) for img in imgs]
 
-        self.masker_ = check_embedded_masker(self)
+        self.masker_ = _check_embedded_nifti_masker(self)
         self.masker_.n_jobs = self.n_jobs  # self.n_jobs
 
         # if masker_ has been provided a mask_img

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "joblib",
     "scipy",
     "nibabel",
-    "nilearn@git+https://github.com/nilearn/nilearn#egg=1b11edf5789813d20995e7744bc58f3a2b6bc4ea",
+    "nilearn>=0.10.2",
     "POT"
 ]
 dynamic = ["version"]


### PR DESCRIPTION
We had needed a few unreleased Nilearn updates, but this is no longer the case, so reverts to the safer practice of setting minimum versions.

Here we set 0.10.2 as the minimum, since it's the first version with surface support, which we'd like to integrate soon ! This should update this and get all tests to green.