### PR TITLE
[DOC] Restrict deploy job to run only on the main branch

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -46,7 +46,7 @@ jobs:
 
   deploy:
     # Avoid running this job on a fork
-    if: github.repository == 'parietal-INRIA/fmralign'
+    if: github.repository == 'parietal-INRIA/fmralign' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This is a quickfix to avoid running the deploy action when on a PR.