### PR TITLE
[INFRA] Expanding supported Python versions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # fmralign
 
+![build](https://img.shields.io/github/actions/workflow/status/parietal-inria/fmralign/testing.yml?event=push&style=for-the-badge)
+![python version](https://img.shields.io/badge/python-3.9_|_3.10_|_3.11|_3.12|_3.13-blue?style=for-the-badge)
+![license](https://img.shields.io/github/license/parietal-inria/fmralign?style=for-the-badge)
+
 [Functional alignment for fMRI](https://parietal-inria.github.io/fmralign-docs) (functional Magnetic Resonance Imaging) data.
 
 This light-weight Python library provides access to a range of functional alignment methods, including Procrustes and Optimal Transport.
 It is compatible with and inspired by [Nilearn](http://nilearn.github.io).
 Alternative implementations of these ideas can be found in the [pymvpa](http://www.pymvpa.org) or [brainiak](http://brainiak.org) packages.
-
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fmralign
 
 ![build](https://img.shields.io/github/actions/workflow/status/parietal-inria/fmralign/testing.yml?event=push&style=for-the-badge)
-![python version](https://img.shields.io/badge/python-3.9_|_3.10_|_3.11|_3.12|_3.13-blue?style=for-the-badge)
+![python version](https://img.shields.io/badge/python-3.9_|_3.10_|_3.11|_3.12-blue?style=for-the-badge)
 ![license](https://img.shields.io/github/license/parietal-inria/fmralign?style=for-the-badge)
 
 [Functional alignment for fMRI](https://parietal-inria.github.io/fmralign-docs) (functional Magnetic Resonance Imaging) data.


### PR DESCRIPTION
Addresses #93 

- Tests py3.12 support
- ~Tests py3.13 support~
- Documents supported versions in README