### PR TITLE
Refactor template alignments to keep a fixed parcellation

### DIFF
--- a/examples/plot_template_alignment.py
+++ b/examples/plot_template_alignment.py
@@ -8,7 +8,7 @@ computed across multiple source subjects. For this purpose, we create a template
 using Procrustes alignment (hyperalignment) to which we align the target subject,
 using shared information. We then compare the voxelwise similarity between the
 target subject and the template to the similarity between the target subject and
-the anatomical euclidean average of the source subjects.
+the anatomical Euclidean average of the source subjects.
 
 We mostly rely on Python common packages and on nilearn to handle
 functional data in a clean fashion.

--- a/examples/plot_template_alignment.py
+++ b/examples/plot_template_alignment.py
@@ -66,7 +66,7 @@ template_train = []
 for i in range(5):
     template_train.append(concat_imgs(imgs[i]))
 
-# sub-07 will be our left-out subject.
+# sub-07 (that is 5th in the list) will be our left-out subject.
 # We make a single 4D Niimg from our list of 3D filenames.
 
 left_out_subject = concat_imgs(imgs[5])

--- a/fmralign/pairwise_alignment.py
+++ b/fmralign/pairwise_alignment.py
@@ -237,12 +237,12 @@ class PairwiseAlignment(BaseEstimator, TransformerMixin):
 
         return self
 
-    def transform(self, X):
+    def transform(self, img):
         """Predict data from X.
 
         Parameters
         ----------
-        X: Niimg-like object
+        img: Niimg-like object
             Source data
 
         Returns
@@ -255,7 +255,7 @@ class PairwiseAlignment(BaseEstimator, TransformerMixin):
                 "This instance has not been fitted yet. "
                 "Please call 'fit' before 'transform'."
             )
-        parceled_data_list = self.parcel_masker.transform(X)
+        parceled_data_list = self.parcel_masker.transform(img)
         transformed_img = Parallel(
             self.n_jobs, prefer="threads", verbose=self.verbose
         )(
@@ -266,7 +266,6 @@ class PairwiseAlignment(BaseEstimator, TransformerMixin):
             return transformed_img[0]
         else:
             return transformed_img
-        return transformed_img
 
     # Make inherited function harmless
     def fit_transform(self):
@@ -291,7 +290,7 @@ class PairwiseAlignment(BaseEstimator, TransformerMixin):
         if hasattr(self, "parcel_masker"):
             check_is_fitted(self)
             labels = self.parcel_masker.get_labels()
-            parcellation_img = self.parcel_masker.get_parcellation()
+            parcellation_img = self.parcel_masker.get_parcellation_img()
             return labels, parcellation_img
         else:
             raise AttributeError(

--- a/fmralign/preprocessing.py
+++ b/fmralign/preprocessing.py
@@ -186,7 +186,7 @@ class ParcellationMasker(BaseEstimator, TransformerMixin):
             )
         return self.labels
 
-    def get_parcellation(self):
+    def get_parcellation_img(self):
         """Return the parcellation image.
 
         Returns

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -163,13 +163,13 @@ def _fit_local_template(
     }
 
 
-def index_by_parcel(subjects_data):
+def _index_by_parcel(subjects_parcels):
     """
     Index data by parcel.
 
     Parameters
     ----------
-    subjects_data: list of list of numpy.ndarray
+    subjects_parcels: list of list of numpy.ndarray
         Each element of the list is the list of parcels
         data for one subject.
 
@@ -179,9 +179,9 @@ def index_by_parcel(subjects_data):
         Each element of the list is the list of subjects
         data for one parcel.
     """
-    n_pieces = subjects_data[0].n_pieces
+    n_pieces = subjects_parcels[0].n_pieces
     return [
-        [subject_data[i] for subject_data in subjects_data]
+        [subject_parcels[i] for subject_parcels in subjects_parcels]
         for i in range(n_pieces)
     ]
 

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -84,18 +84,11 @@ def _align_images_to_template(
     return aligned_imgs
 
 
-def _create_template(
-    imgs,
+def _fit_local_template(
+    subjects_data,
     n_iter,
     scale_template,
     alignment_method,
-    n_pieces,
-    clustering,
-    masker,
-    memory,
-    memory_level,
-    n_jobs,
-    verbose,
 ):
     """
     Create template through alternate minimization.
@@ -127,28 +120,23 @@ def _create_template(
         List of the intermediate templates computed at the end of each iteration
     """
 
-    aligned_imgs = imgs
+    aligned_data = subjects_data
     template_history = []
     for iter in range(n_iter):
-        template = _rescaled_euclidean_mean(
-            aligned_imgs, masker, scale_template
-        )
+        template = _rescaled_euclidean_mean(aligned_data, scale_template)
         if 0 < iter < n_iter - 1:
             template_history.append(template)
-        aligned_imgs = _align_images_to_template(
-            imgs,
+        aligned_data, subjects_estimators = _align_images_to_template(
+            subjects_data,
             template,
             alignment_method,
-            n_pieces,
-            clustering,
-            masker,
-            memory,
-            memory_level,
-            n_jobs,
-            verbose,
         )
 
-    return template, template_history
+    return {
+        "template_data": template,
+        "template_history": template_history,
+        "estimators": subjects_estimators,
+    }
 
 
 def _map_template_to_image(

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -164,55 +164,6 @@ def _fit_local_template(
     }
 
 
-def _map_template_to_image(
-    imgs,
-    train_index,
-    template,
-    alignment_method,
-    n_pieces,
-    clustering,
-    masker,
-    memory,
-    memory_level,
-    n_jobs,
-    verbose,
-):
-    """
-    Learn alignment operator from the template toward new images.
-
-    Parameters
-    ----------
-    imgs: list of 3D Niimgs
-        Target images to learn mapping from the template to a new subject
-    train_index: list of int
-        Matching index between imgs and the corresponding template images to use
-        to learn alignment. len(train_index) must be equal to len(imgs)
-    template: list of 3D Niimgs
-        Learnt in a first step now used as source image
-    All other arguments are the same are passed to PairwiseAlignment
-
-
-    Returns
-    -------
-    mapping: instance of PairwiseAlignment class
-        Alignment estimator fitted to align the template with the input images
-    """
-
-    mapping_image = index_img(template, train_index)
-    mapping = PairwiseAlignment(
-        n_pieces=n_pieces,
-        alignment_method=alignment_method,
-        clustering=clustering,
-        mask=masker,
-        memory=memory,
-        memory_level=memory_level,
-        n_jobs=n_jobs,
-        verbose=verbose,
-    )
-    mapping.fit(mapping_image, imgs)
-    return mapping
-
-
 def _predict_from_template_and_mapping(template, test_index, mapping):
     """
     From a template and an alignment estimator, predict new contrasts.

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -110,9 +110,9 @@ def _align_images_to_template(
 
 def _fit_local_template(
     subjects_data,
-    n_iter,
-    scale_template,
-    alignment_method,
+    n_iter=2,
+    scale_template=False,
+    alignment_method="identity",
 ):
     """
     Create template through alternate minimization.

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -8,7 +8,6 @@ Uses functional alignment on Niimgs and predicts new subjects' unseen images.
 
 import numpy as np
 from joblib import Memory, Parallel, delayed
-from nilearn.image import index_img
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
@@ -162,31 +161,6 @@ def _fit_local_template(
         "template_history": template_history,
         "estimators": subjects_estimators,
     }
-
-
-def _predict_from_template_and_mapping(template, test_index, mapping):
-    """
-    From a template and an alignment estimator, predict new contrasts.
-
-    Parameters
-    ----------
-    template: list of 3D Niimgs
-        Learnt in a first step now used to predict some new data
-    test_index:
-        Index of the images not used to learn the alignment mapping and so
-        predictable without overfitting
-    mapping: instance of PairwiseAlignment class
-        Alignment estimator that must have been fitted already
-
-    Returns
-    -------
-    transformed_image: list of Niimgs
-        Prediction corresponding to each template image with index in test_index
-        once realigned to the new subjects
-    """
-    image_to_transform = index_img(template, test_index)
-    transformed_image = mapping.transform(image_to_transform)
-    return transformed_image
 
 
 def index_by_parcel(subjects_data):

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -225,6 +225,29 @@ def _predict_from_template_and_mapping(template, test_index, mapping):
     return transformed_image
 
 
+def index_by_parcel(subjects_data):
+    """
+    Index data by parcel.
+
+    Parameters
+    ----------
+    subjects_data: list of list of numpy.ndarray
+        Each element of the list is the list of parcels
+        data for one subject.
+
+    Returns
+    -------
+    list of list of numpy.ndarray
+        Each element of the list is the list of subjects
+        data for one parcel.
+    """
+    n_pieces = subjects_data[0].n_pieces
+    return [
+        [subject_data[i] for subject_data in subjects_data]
+        for i in range(n_pieces)
+    ]
+
+
 class TemplateAlignment(BaseEstimator, TransformerMixin):
     """
     Decompose the source images into regions and summarize subjects information

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -348,8 +348,8 @@ class TemplateAlignment(BaseEstimator, TransformerMixin):
             verbose=self.verbose,
         )
 
-        subjects_data = self.parcel_masker.fit_transform(imgs)
-        parcels_data = index_by_parcel(subjects_data)
+        subjects_parcels = self.parcel_masker.fit_transform(imgs)
+        parcels_data = _index_by_parcel(subjects_parcels)
         self.masker = self.parcel_masker.masker_
         self.mask = self.parcel_masker.masker_.mask_img_
         self.labels_ = self.parcel_masker.labels

--- a/fmralign/tests/test_preprocessing.py
+++ b/fmralign/tests/test_preprocessing.py
@@ -181,13 +181,13 @@ def test_standardization():
     assert np.abs(np.std(data_array) - 1.0) < 1e-5
 
 
-def test_get_parcellation():
+def test_get_parcellatio_img():
     """Test that ParcellationMasker returns the parcellation mask"""
     n_pieces = 2
     img, _ = random_niimg((8, 7, 6))
     parcel_masker = ParcellationMasker(n_pieces=n_pieces)
     parcel_masker.fit(img)
-    parcellation_img = parcel_masker.get_parcellation()
+    parcellation_img = parcel_masker.get_parcellation_img()
     labels = parcel_masker.get_labels()
 
     assert isinstance(parcellation_img, Nifti1Image)

--- a/fmralign/tests/test_preprocessing.py
+++ b/fmralign/tests/test_preprocessing.py
@@ -208,3 +208,11 @@ def test_get_parcellation_img():
     assert np.allclose(data, labels)
     assert len(np.unique(data)) == n_pieces
 
+
+def test_one_contrast():
+    """Test that ParcellationMasker handles both 3D and\n
+    4D images in the case of one contrast"""
+    img1, _ = random_niimg((8, 7, 6))
+    img2, _ = random_niimg((8, 7, 6, 1))
+    pmasker = ParcellationMasker()
+    pmasker.fit([img1, img2])

--- a/fmralign/tests/test_preprocessing.py
+++ b/fmralign/tests/test_preprocessing.py
@@ -207,12 +207,3 @@ def test_get_parcellation_img():
 
     assert np.allclose(data, labels)
     assert len(np.unique(data)) == n_pieces
-
-
-def test_one_contrast():
-    """Test that ParcellationMasker handles both 3D and\n
-    4D images in the case of one contrast"""
-    img1, _ = random_niimg((8, 7, 6))
-    img2, _ = random_niimg((8, 7, 6, 1))
-    pmasker = ParcellationMasker()
-    pmasker.fit([img1, img2])

--- a/fmralign/tests/test_template_alignment.py
+++ b/fmralign/tests/test_template_alignment.py
@@ -1,18 +1,105 @@
 import numpy as np
 import pytest
 from nibabel import Nifti1Image
-from nilearn.image import concat_imgs, index_img, math_img
+from nilearn.image import concat_imgs, math_img
 from nilearn.maskers import NiftiMasker
 from numpy.testing import assert_array_almost_equal
 
+from fmralign._utils import ParceledData
+from fmralign.preprocessing import ParcellationMasker
 from fmralign.template_alignment import (
     TemplateAlignment,
+    _align_images_to_template,
+    _fit_local_template,
+    _index_by_parcel,
+    _reconstruct_template,
     _rescaled_euclidean_mean,
 )
 from fmralign.tests.utils import (
     random_niimg,
+    sample_parceled_data,
+    sample_subjects_data,
     zero_mean_coefficient_determination,
 )
+
+
+@pytest.mark.parametrize("scale_average", [True, False])
+def test_rescaled_euclidean_mean(scale_average):
+    subjects_data = sample_subjects_data()
+    average_data = _rescaled_euclidean_mean(subjects_data)
+    assert average_data.shape == subjects_data[0].shape
+    assert average_data.dtype == subjects_data[0].dtype
+
+    if scale_average is False:
+        assert np.allclose(average_data, np.mean(subjects_data, axis=0))
+
+
+def test_reconstruct_template():
+    n_subjects = 3
+    n_iter = 3
+    n_pieces = 2
+    imgs = [random_niimg((8, 7, 6, 20))[0]] * n_subjects
+    parcel_masker = ParcellationMasker(n_pieces=n_pieces)
+    subjects_parcels = parcel_masker.fit_transform(imgs)
+    parcels_subjects = _index_by_parcel(subjects_parcels)
+    masker = parcel_masker.masker_
+    labels = parcel_masker.labels
+
+    fit = [
+        _fit_local_template(parcel_i, n_iter=n_iter)
+        for parcel_i in parcels_subjects
+    ]
+    template, template_history = _reconstruct_template(fit, labels, masker)
+
+    assert template.shape == imgs[0].shape
+    assert len(template_history) == n_iter - 2
+    for template_i in template_history:
+        assert template_i.shape == imgs[0].shape
+
+
+def test_align_images_to_template():
+    subjects_data = sample_subjects_data()
+    template = _rescaled_euclidean_mean(subjects_data)
+    aligned_data, subjects_estimators = _align_images_to_template(
+        subjects_data,
+        template,
+        alignment_method="identity",
+    )
+    assert len(aligned_data) == len(subjects_data)
+    assert len(subjects_estimators) == len(subjects_data)
+    assert aligned_data[0].shape == subjects_data[0].shape
+
+
+def test_fit_local_template():
+    n_subjects = 3
+    n_iter = 3
+    subjects_data = sample_subjects_data(n_subjects=n_subjects)
+    fit = _fit_local_template(
+        subjects_data,
+        n_iter=n_iter,
+        alignment_method="identity",
+        scale_template=False,
+    )
+    template_data = fit["template_data"]
+    template_history = fit["template_history"]
+    estimators = fit["estimators"]
+
+    assert template_data.shape == subjects_data[0].shape
+    assert len(template_history) == n_iter - 2
+    assert len(estimators) == n_subjects
+
+
+def test_index_by_parcel():
+    n_subjects = 3
+    n_pieces = 2
+    subjects_parcels = [
+        ParceledData(*sample_parceled_data(n_pieces))
+        for _ in range(n_subjects)
+    ]
+    parcels_subjects = _index_by_parcel(subjects_parcels)
+    assert len(parcels_subjects) == n_pieces
+    assert len(parcels_subjects[0]) == n_subjects
+    assert parcels_subjects[0][0].shape == subjects_parcels[0][0].shape
 
 
 def test_template_identity():
@@ -29,15 +116,9 @@ def test_template_identity():
 
     subs = [sub_1, sub_2, sub_3]
 
-    # # test euclidian mean function
-    # euclidian_template = _rescaled_euclidean_mean(subs, masker)
-    # assert_array_almost_equal(
-    #     ref_template.get_fdata(), euclidian_template.get_fdata()
-    # )
-
     # test different fit() accept list of list of 3D Niimgs as input.
     algo = TemplateAlignment(alignment_method="identity", mask=masker)
-    algo.fit([n * [im]] * 3)
+    algo.fit([concat_imgs(n * [im])] * 3)
     # test template
     assert_array_almost_equal(sub_1.get_fdata(), algo.template.get_fdata())
 
@@ -55,55 +136,53 @@ def test_template_identity():
 
     for args in args_list:
         algo = TemplateAlignment(**args)
-        # Learning a template which is
         algo.fit(subs)
         # test template
         assert_array_almost_equal(
             ref_template.get_fdata(),
             algo.template.get_fdata(),
         )
-        predicted_imgs = algo.transform(
-            [index_img(sub_1, range(8))],
-            train_index=range(8),
-            test_index=range(8, 10),
-        )
-        ground_truth = index_img(ref_template, range(8, 10))
+        predicted_imgs = algo.transform(ref_template)
         assert_array_almost_equal(
-            ground_truth.get_fdata(),
-            predicted_imgs[0].get_fdata(),
+            predicted_imgs.get_fdata(),
+            ref_template.get_fdata(),
+        )
+        predicted_imgs = algo.transform(ref_template, subject_index=1)
+        assert_array_almost_equal(
+            predicted_imgs.get_fdata(),
+            ref_template.get_fdata(),
         )
 
-    # test transform() with wrong indexes length or content (on previous fitted algo)
-    train_inds, test_inds = (
-        [[0, 1], [1, 10], [4, 11], [0, 1, 2]],
-        [
-            [6, 8, 29],
-            [4, 6],
-            [4, 11],
-            [4, 5],
-        ],
+
+def test_template_diagonal():
+    n = 10
+    im, mask_img = random_niimg((6, 5, 3))
+
+    sub_1 = concat_imgs(n * [im])
+    sub_2 = math_img("2 * img", img=sub_1)
+    sub_3 = math_img("3 * img", img=sub_1)
+
+    ref_template = sub_2
+    masker = NiftiMasker(mask_img=mask_img)
+    masker.fit()
+
+    subs = [sub_1, sub_2, sub_3]
+
+    # Test without subject_index
+    algo = TemplateAlignment(alignment_method="diagonal", mask=masker)
+    algo.fit(subs)
+    predicted_imgs = algo.transform(sub_1, subject_index=None)
+    assert_array_almost_equal(
+        ref_template.get_fdata(),
+        predicted_imgs.get_fdata(),
     )
 
-    for train_ind, test_ind in zip(train_inds, test_inds, strict=False):
-        with pytest.raises(Exception):
-            assert algo.transform(
-                [index_img(sub_1, range(2))],
-                train_index=train_ind,
-                test_index=test_ind,
-            )
-
-    # test wrong images input in fit() and transform method
-    with pytest.raises(Exception):
-        assert algo.transform(
-            [n * [im]] * 2,
-            train_index=train_inds[-1],
-            test_index=test_inds[-1],
-        )
-        assert algo.fit([im])
-        assert algo.transform(
-            [im],
-            train_index=train_inds[-1],
-            test_index=test_inds[-1],
+    # Test with subject_index
+    for i, sub in enumerate(subs):
+        predicted_imgs = algo.transform(sub, subject_index=i)
+        assert_array_almost_equal(
+            predicted_imgs.get_fdata(),
+            ref_template.get_fdata(),
         )
 
 
@@ -121,8 +200,7 @@ def test_template_closer_to_target():
     sub_1 = masker.transform(subject_1)
     sub_2 = masker.transform(subject_2)
     subs = [subject_1, subject_2]
-    average_img = _rescaled_euclidean_mean(subs, masker)
-    avg_data = masker.transform(average_img)
+    avg_data = np.mean([sub_1, sub_2], axis=0)
     mean_distance_1 = zero_mean_coefficient_determination(sub_1, avg_data)
     mean_distance_2 = zero_mean_coefficient_determination(sub_2, avg_data)
 
@@ -178,20 +256,3 @@ def test_parcellation_before_fit():
         match="Parcellation has not been computed yet",
     ):
         alignment.get_parcellation()
-
-
-if __name__ == "__main__":
-    #     imgs = [random_niimg((8, 7, 6, 100))[0]] * 3
-    #     template_estimator = TemplateAlignment(
-    #         alignment_method="identity",
-    #         n_pieces=2,
-    #     )
-    #     template_estimator.fit(imgs)
-    #     res_img = template_estimator.transform(random_niimg((8, 7, 6, 100))[0])
-    #     print(res_img.shape)
-    #     print(template_estimator.template.shape)
-    #     print(template_estimator.get_parcellation())
-    test_template_identity()
-    # test_template_closer_to_target()
-    # test_parcellation_retrieval()
-    # test_parcellation_before_fit()

--- a/fmralign/tests/test_template_alignment.py
+++ b/fmralign/tests/test_template_alignment.py
@@ -243,7 +243,7 @@ def test_parcellation_retrieval():
     assert isinstance(labels, np.ndarray)
     assert len(np.unique(labels)) == n_pieces
     assert isinstance(parcellation_image, Nifti1Image)
-    assert parcellation_image.shape == imgs[0].shape
+    assert parcellation_image.shape == imgs[0].shape[:-1]
 
 
 def test_parcellation_before_fit():
@@ -256,3 +256,7 @@ def test_parcellation_before_fit():
         match="Parcellation has not been computed yet",
     ):
         alignment.get_parcellation()
+
+
+if __name__ == "__main__":
+    test_parcellation_retrieval()

--- a/fmralign/tests/utils.py
+++ b/fmralign/tests/utils.py
@@ -132,3 +132,9 @@ def sample_parceled_data(n_pieces=1):
     data = masker.fit_transform(img)
     labels = _make_parcellation(img, "kmeans", n_pieces, masker)
     return data, masker, labels
+
+
+def sample_subjects_data(n_subjects=3):
+    """Sample data in one parcel for n_subjects"""
+    subjects_data = [np.random.rand(10, 20) for _ in range(n_subjects)]
+    return subjects_data


### PR DESCRIPTION
Closes #86. Uses the new backend to distribute template computations across parcels.

- [x] Docstrings
- [x] Unit tests
- [x] Adapt `examples/plot_template_alignment.py`  