### PR TITLE
[HOTFIX] Enable POT usage in PairwiseAlignment

### DIFF
--- a/fmralign/pairwise_alignment.py
+++ b/fmralign/pairwise_alignment.py
@@ -56,6 +56,7 @@ def fit_one_piece(X_i, Y_i, alignment_method):
             alignment_methods.Hungarian,
             alignment_methods.OptimalTransportAlignment,
             alignment_methods.DiagonalAlignment,
+            alignment_methods.POTAlignment,
         ),
     ):
         alignment_algo = clone(alignment_method)


### PR DESCRIPTION
Adds POT alignment to available methods in pairwise aligment.