### PR TITLE
[ENH] Replace FUGW by clusterized sparse UOT

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,6 @@ import os
 import sys
 from pathlib import Path
 
-
 import fmralign
 
 # If extensions (or modules to document with autodoc) are in another

--- a/fmralign/_utils.py
+++ b/fmralign/_utils.py
@@ -271,7 +271,7 @@ def _make_parcellation(
     return labels
 
 
-def _create_sparse_cluster_matrix(arr):
+def _sparse_cluster_matrix(arr):
     """
     Creates a sparse matrix where element (i,j) is 1 if arr[i] == arr[j], 0 otherwise.
 
@@ -306,11 +306,13 @@ def _create_sparse_cluster_matrix(arr):
     # Convert to tensors
     rows = torch.tensor(rows)
     cols = torch.tensor(cols)
-    values = torch.ones(len(rows), dtype=torch.float)
+    values = torch.ones(len(rows), dtype=torch.bool)
 
     # Create sparse tensor
     sparse_matrix = torch.sparse_coo_tensor(
-        indices=torch.stack([rows, cols]), values=values, size=(n, n)
+        indices=torch.stack([rows, cols]),
+        values=values,
+        size=(n, n),
     ).coalesce()
 
     return sparse_matrix

--- a/fmralign/_utils.py
+++ b/fmralign/_utils.py
@@ -299,9 +299,8 @@ def _sparse_cluster_matrix(arr):
     # For each value, add all pairs of indices where that value appears
     for indices in value_to_indices.values():
         for i in indices:
-            for j in indices:
-                rows.append(i)
-                cols.append(j)
+            rows += [i] * len(indices)
+            cols += indices
 
     # Convert to tensors
     rows = torch.tensor(rows)

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -783,7 +783,7 @@ class SparseUOT(Alignment):
     def __init__(
         self,
         sparsity_mask,
-        solver="mm",
+        solver="sinkhorn",
         rho=float("inf"),
         reg=0.1,
         max_iter=1000,

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -362,7 +362,7 @@ class POTAlignment(Alignment):
     def __init__(
         self,
         solver="sinkhorn_epsilon_scaling",
-        metric="sqeuclidean",
+        metric="euclidean",
         reg=1,
         max_iter=1000,
         tol=1e-3,
@@ -445,7 +445,7 @@ class OptimalTransportAlignment(Alignment):
     """
 
     def __init__(
-        self, metric="sqeuclidean", reg=1, tau=1.0, max_iter=1000, tol=1e-3
+        self, metric="euclidean", reg=1, tau=1.0, max_iter=1000, tol=1e-3
     ):
         self.metric = metric
         self.reg = reg
@@ -843,6 +843,7 @@ class SparseUOT(Alignment):
         cost_values = batch_elementwise_prod_and_sum(
             F[0], F[1], row_indices, col_indices, 1
         )
+        cost_values = torch.sqrt(cost_values)
         return _make_csr_matrix(
             crow_indices,
             col_indices,

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -762,7 +762,6 @@ class SparseUOT(Alignment):
     Parameters
     ----------
     sparsity_mask : sparse torch.Tensor of shape (n_features, n_features)
-    solver : str (optional)
     rho : float (optional)
     reg : float (optional)
     max_iter : int (optional)
@@ -835,6 +834,8 @@ class SparseUOT(Alignment):
         )
         # Take the square root to match torch.cdist
         cost_values = torch.sqrt(cost_values)
+        # Normalize the cost matrix to avoid numerical instability
+        cost_values = cost_values / cost_values.sum()
         return _make_csr_matrix(
             crow_indices,
             col_indices,

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -950,12 +950,11 @@ class SparseUOT(Alignment):
 
     def transform(self, X):
         """Transform X using optimal coupling computed during fit."""
-        X_ = torch.tensor(X, device=self.device)
         transformed_data = (
             (
                 torch.sparse.mm(
                     self.pi.transpose(0, 1),
-                    X_.T,
+                    X.T,
                 ).to_dense()
                 / (
                     torch.sparse.sum(self.pi, dim=0).to_dense().reshape(-1, 1)

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -362,7 +362,7 @@ class POTAlignment(Alignment):
     def __init__(
         self,
         solver="sinkhorn_epsilon_scaling",
-        metric="euclidean",
+        metric="sqeuclidean",
         reg=1,
         max_iter=1000,
         tol=1e-3,
@@ -445,7 +445,7 @@ class OptimalTransportAlignment(Alignment):
     """
 
     def __init__(
-        self, metric="euclidean", reg=1, tau=1.0, max_iter=1000, tol=1e-3
+        self, metric="sqeuclidean", reg=1, tau=1.0, max_iter=1000, tol=1e-3
     ):
         self.metric = metric
         self.reg = reg

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -834,8 +834,6 @@ class SparseUOT(Alignment):
         )
         # Take the square root to match torch.cdist
         cost_values = torch.sqrt(cost_values)
-        # Normalize the cost matrix to avoid numerical instability
-        cost_values = cost_values / cost_values.sum()
         return _make_csr_matrix(
             crow_indices,
             col_indices,

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -895,7 +895,7 @@ class SparseUOT(Alignment):
         )
 
         # Convert pi to coo format
-        self.pi = pi.to_sparse_coo().detach()
+        self.R = pi.to_sparse_coo().detach() * n_features
 
         return self
 

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -793,7 +793,7 @@ class SparseUOT(Alignment):
         rho=float("inf"),
         reg=0.1,
         max_iter=1000,
-        tol=1e-7,
+        tol=1e-3,
         eval_freq=10,
         device="cpu",
         verbose=False,

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -757,18 +757,29 @@ class IndividualizedNeuralTuning(Alignment):
 class SparseUOT(Alignment):
     """
     Compute the unbalanced regularized optimal coupling between X and Y,
-    with sparsity constraints inspired by the FUGW package.
+    with sparsity constraints inspired by the FUGW package sparse
+    sinkhorn solver.
+    (https://github.com/alexisthual/fugw/blob/main/src/fugw/solvers/sparse.py)
 
     Parameters
     ----------
     sparsity_mask : sparse torch.Tensor of shape (n_features, n_features)
+        Sparse mask that defines the sparsity pattern of the coupling matrix.
     rho : float (optional)
+        Strength of the unbalancing constraint. Lower values will favor lower
+        mass transport. Defaults to infinity.
     reg : float (optional)
+        Strength of the entropic regularization. Defaults to 0.1.
     max_iter : int (optional)
+        Maximum number of iterations. Defaults to 1000.
     tol : float (optional)
+        Tolerance for stopping criterion. Defaults to 1e-7.
     eval_freq : int (optional)
+        Frequency of evaluation of the stopping criterion. Defaults to 10.
     device : str (optional)
+        Device on which to perform computations. Defaults to 'cpu'.
     verbose : bool (optional)
+        Whether to print progress information. Defaults to False.
 
     Attributes
     ----------
@@ -887,7 +898,18 @@ class SparseUOT(Alignment):
         return self
 
     def transform(self, X):
-        """Transform X using optimal coupling computed during fit."""
+        """Transform X using optimal coupling computed during fit.
+
+        Parameters
+        ----------
+        X : torch.Tensor of shape (n_samples, n_features)
+            Input data to be transformed
+
+        Returns
+        -------
+        torch.Tensor of shape (n_samples, n_features)
+            Transformed data
+        """
         transformed_data = (
             torch.sparse.mm(
                 self.pi.transpose(0, 1),

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -845,6 +845,8 @@ class SparseUOT(Alignment):
         )
         # Take the square root to match torch.cdist
         cost_values = torch.sqrt(cost_values)
+        # Normalize the cost values
+        cost_values = cost_values / cost_values.sum()
         return _make_csr_matrix(
             crow_indices,
             col_indices,

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -855,11 +855,9 @@ class SparseUOT(Alignment):
         """
         n_features = X.shape[1]
         F = _low_rank_squared_l2(X.T, Y.T)
-        F_norm = (F[0] @ F[1].T).max()
-        F_normalized = (F[0] / F_norm, F[1] / F_norm)
 
         init_plan = self._initialize_plan(n_features)
-        cost = self._uot_cost(init_plan, F_normalized, n_features)
+        cost = self._uot_cost(init_plan, F, n_features)
         weights, ws_dot_wt = self._initialize_weights(n_features, cost)
 
         uot_params = (

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -843,6 +843,8 @@ class SparseUOT(Alignment):
         cost_values = batch_elementwise_prod_and_sum(
             F[0], F[1], row_indices, col_indices, 1
         )
+        # Clamp negative values to avoid numerical errors
+        cost_values = torch.clamp(cost_values, min=0.0)
         cost_values = torch.sqrt(cost_values)
         return _make_csr_matrix(
             crow_indices,

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -912,15 +912,4 @@ class SparseUOT(Alignment):
         torch.Tensor of shape (n_samples, n_features)
             Transformed data
         """
-        transformed_data = (
-            torch.sparse.mm(
-                self.pi.transpose(0, 1),
-                X.T,
-            ).to_dense()
-            / (
-                torch.sparse.sum(self.pi, dim=0).to_dense().reshape(-1, 1)
-                # Add very small value to handle null rows
-                + 1e-16
-            )
-        ).T
-        return transformed_data
+        return (X @ self.R).to_dense()

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -891,18 +891,14 @@ class SparseUOT(Alignment):
     def transform(self, X):
         """Transform X using optimal coupling computed during fit."""
         transformed_data = (
-            (
-                torch.sparse.mm(
-                    self.pi.transpose(0, 1),
-                    X.T,
-                ).to_dense()
-                / (
-                    torch.sparse.sum(self.pi, dim=0).to_dense().reshape(-1, 1)
-                    # Add very small value to handle null rows
-                    + 1e-16
-                )
+            torch.sparse.mm(
+                self.pi.transpose(0, 1),
+                X.T,
+            ).to_dense()
+            / (
+                torch.sparse.sum(self.pi, dim=0).to_dense().reshape(-1, 1)
+                # Add very small value to handle null rows
+                + 1e-16
             )
-            .T.detach()
-            .cpu()
-        )
+        ).T
         return transformed_data

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -896,6 +896,12 @@ class SparseUOT(Alignment):
         # Convert pi to coo format
         self.R = pi.to_sparse_coo().detach() * n_features
 
+        if self.R.values().isnan().any():
+            raise ValueError(
+                "Coupling matrix contains NaN values,"
+                "try increasing the regularization parameter."
+            )
+
         return self
 
     def transform(self, X):

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -843,10 +843,6 @@ class SparseUOT(Alignment):
         cost_values = batch_elementwise_prod_and_sum(
             F[0], F[1], row_indices, col_indices, 1
         )
-        # Take the square root to match torch.cdist
-        cost_values = torch.sqrt(cost_values)
-        # Normalize the cost values
-        cost_values = cost_values / cost_values.sum()
         return _make_csr_matrix(
             crow_indices,
             col_indices,

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -833,8 +833,8 @@ class SparseUOT(Alignment):
         cost_values = batch_elementwise_prod_and_sum(
             F[0], F[1], row_indices, col_indices, 1
         )
-        # Normalize cost values
-        cost_values = cost_values / cost_values.sum()
+        # Take the square root to match torch.cdist
+        cost_values = torch.sqrt(cost_values)
         return _make_csr_matrix(
             crow_indices,
             col_indices,
@@ -858,6 +858,7 @@ class SparseUOT(Alignment):
 
         init_plan = self._initialize_plan(n_features)
         cost = self._uot_cost(init_plan, F, n_features)
+
         weights, ws_dot_wt = self._initialize_weights(n_features, cost)
 
         uot_params = (

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -2,7 +2,6 @@
 """Module implementing alignment estimators on ndarrays."""
 
 import warnings
-from collections import defaultdict
 
 import numpy as np
 import ot

--- a/fmralign/alignment_methods.py
+++ b/fmralign/alignment_methods.py
@@ -791,7 +791,7 @@ class SparseUOT(Alignment):
         self,
         sparsity_mask,
         rho=float("inf"),
-        reg=0.1,
+        reg=1,
         max_iter=1000,
         tol=1e-3,
         eval_freq=10,

--- a/fmralign/sparse_pairwise_alignment.py
+++ b/fmralign/sparse_pairwise_alignment.py
@@ -170,7 +170,7 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
             self.fit_ = SparseUOT(
                 sparsity_mask=sparsity_mask,
                 device=self.device,
-                verbose=self.verbose,
+                verbose=True if self.verbose > 0 else False,
                 **self.kwargs,
             ).fit(X, Y)
         else:

--- a/fmralign/sparse_pairwise_alignment.py
+++ b/fmralign/sparse_pairwise_alignment.py
@@ -41,11 +41,8 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         alignment_method: string
-            Algorithm used to perform alignment between X_i and Y_i :
-            * either 'identity', 'scaled_orthogonal', 'optimal_transport',
-            'ridge_cv', 'permutation', 'diagonal'
-            * or an instance of one of alignment classes
-            (imported from fmralign.alignment_methods)
+            Algorithm used to perform alignment between X and Y.
+            Currently, only 'sparse_uot' is available.
         n_pieces: int, optional (default = 1)
             Number of regions in which the data is parcellated for alignment.
             If 1 the alignment is done on full scale data.
@@ -94,6 +91,9 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
         memory_level: integer, optional (default = None)
             Rough estimator of the amount of memory used by caching.
             Higher value means more memory for caching.
+        device: string, optional (default = 'cpu')
+            Device on which the computation will be done. If 'cuda', the
+            computation will be done on the GPU if available.
         n_jobs: integer, optional (default = 1)
             The number of CPUs to use to do the computation. -1 means
             'all CPUs', -2 'all CPUs but one', and so on.

--- a/fmralign/sparse_pairwise_alignment.py
+++ b/fmralign/sparse_pairwise_alignment.py
@@ -168,7 +168,7 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
             ).fit(X, Y)
         else:
             raise ValueError(
-                "Unknown alignment method: {}".format(self.alignment_method)
+                f"Unknown alignment method: {self.alignment_method}"
             )
 
         return self

--- a/fmralign/sparse_pairwise_alignment.py
+++ b/fmralign/sparse_pairwise_alignment.py
@@ -5,7 +5,7 @@ from joblib import Memory
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
-from fmralign._utils import _create_sparse_cluster_matrix
+from fmralign._utils import _sparse_cluster_matrix
 from fmralign.alignment_methods import SparseUOT
 from fmralign.preprocessing import ParcellationMasker
 
@@ -165,7 +165,7 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
             self.masker.transform(Y), device=self.device, dtype=torch.float32
         )
 
-        sparsity_mask = _create_sparse_cluster_matrix(self.labels_)
+        sparsity_mask = _sparse_cluster_matrix(self.labels_)
         if self.alignment_method == "sparse_uot":
             self.fit_ = SparseUOT(
                 sparsity_mask=sparsity_mask,

--- a/fmralign/sparse_pairwise_alignment.py
+++ b/fmralign/sparse_pairwise_alignment.py
@@ -158,8 +158,12 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
         self.labels_ = self.parcel_masker.labels
         self.n_pieces = self.parcel_masker.n_pieces
 
-        X = torch.tensor(self.masker.transform(X), device=self.device)
-        Y = torch.tensor(self.masker.transform(Y), device=self.device)
+        X = torch.tensor(
+            self.masker.transform(X), device=self.device, dtype=torch.float32
+        )
+        Y = torch.tensor(
+            self.masker.transform(Y), device=self.device, dtype=torch.float32
+        )
 
         sparsity_mask = _create_sparse_cluster_matrix(self.labels_)
         if self.alignment_method == "sparse_uot":
@@ -194,7 +198,9 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
                 "This instance has not been fitted yet. "
                 "Please call 'fit' before 'transform'."
             )
-        X = torch.tensor(self.masker.transform(img), device=self.device)
+        X = torch.tensor(
+            self.masker.transform(img), device=self.device, dtype=torch.float32
+        )
         transformed_data = self.fit_.transform(X)
         transformed_img = self.masker.inverse_transform(
             transformed_data.cpu().detach().numpy()

--- a/fmralign/sparse_pairwise_alignment.py
+++ b/fmralign/sparse_pairwise_alignment.py
@@ -33,6 +33,7 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
         device="cpu",
         n_jobs=1,
         verbose=0,
+        **kwargs,
     ):
         """If n_pieces > 1, decomposes the images into regions and align each
         source/target region independantly.
@@ -116,6 +117,7 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
         self.n_jobs = n_jobs
         self.device = device
         self.verbose = verbose
+        self.kwargs = kwargs
 
     def fit(self, X, Y):
         """Fit data X and Y and learn transformation to map X to Y.
@@ -165,6 +167,7 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
                 sparsity_mask=sparsity_mask,
                 device=self.device,
                 verbose=self.verbose,
+                **self.kwargs,
             ).fit(X, Y)
         else:
             raise ValueError(

--- a/fmralign/sparse_pairwise_alignment.py
+++ b/fmralign/sparse_pairwise_alignment.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-"""Module for pairwise functional alignment."""
+"""Module for sparse pairwise functional alignment."""
 
 import torch
 from joblib import Memory

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -14,6 +14,20 @@ from fmralign.sparse_pairwise_alignment import SparsePairwiseAlignment
 
 
 def _rescaled_euclidean_mean_torch(subjects_data, scale_average=False):
+    """Compute the rescaled euclidean mean of the subjects data.
+
+    Parameters
+    ----------
+    subjects_data : list of torch.Tensor of shape (n_samples, n_features)
+        List of subjects data.
+    scale_average : bool, optional
+        Scale the euclidean template, by default False
+
+    Returns
+    -------
+    average_data : torch.Tensor of shape (n_samples, n_features)
+        Rescaled euclidean mean of the subjects data.
+    """
     average_data = torch.mean(torch.stack(subjects_data), dim=0)
     scale = 1
     if scale_average:
@@ -32,6 +46,23 @@ def _align_images_to_template(
     template,
     subjects_estimators,
 ):
+    """Align the subjects data to the template using sparse alignment.
+
+    Parameters
+    ----------
+    subjects_data : List of torch.Tensor of shape (n_samples, n_features)
+        List of subjects data.
+    template : torch.Tensor of shape (n_samples, n_features)
+        Template data.
+    subjects_estimators : List of alignment_methods.Alignment
+        List of sparse alignment estimators.
+
+    Returns
+    -------
+    Tuple of List of torch.Tensor of shape (n_samples, n_features)
+        and List of alignment_methods.Alignment
+        Updated subjects data and alignment estimators.
+    """
     n_subjects = len(subjects_data)
     for i in range(n_subjects):
         sparse_estimator = subjects_estimators[i]
@@ -51,6 +82,33 @@ def _fit_sparse_template(
     verbose=False,
     **kwargs,
 ):
+    """Fit a the template to the subjects data using sparse alignment.
+
+    Parameters
+    ----------
+    subjects_data : list of torch.Tensor of shape (n_samples, n_features)
+        List of subjects data.
+    sparsity_mask : torch sparse COO tensor
+        Sparsity mask for the alignment matrix.
+    alignment_method : str, optional
+        Sparse alignment method, by default "sparse_uot"
+    n_iter : int, optional
+        Number of template updates, by default 2
+    scale_template : bool, optional
+        Scale the template data at each iteration, by default False
+    verbose : bool, optional
+        Verbosity level, by default False
+
+    Returns
+    -------
+    _type_
+        _description_
+
+    Raises
+    ------
+    ValueError
+        _description_
+    """
     n_subjects = len(subjects_data)
     if alignment_method != "sparse_uot":
         raise ValueError(f"Unknown alignment method: {alignment_method}")
@@ -106,11 +164,8 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         alignment_method: string
-            Algorithm used to perform alignment between X_i and Y_i :
-            * either 'identity', 'scaled_orthogonal', 'optimal_transport',
-            'ridge_cv', 'permutation', 'diagonal',
-            * or an instance of one of alignment classes (imported from
-            fmralign.alignment_methods)
+            Algorithm used to perform alignment between source images
+            and template, currently only 'sparse_uot' is supported.
         n_pieces: int, optional (default = 1)
             Number of regions in which the data is parcellated for alignment.
             If 1 the alignment is done on full scale data.
@@ -167,6 +222,9 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
         memory_level: integer, optional (default = None)
             Rough estimator of the amount of memory used by caching.
             Higher value means more memory for caching.
+        device: string, optional (default = 'cpu')
+            Device on which the computation will be done. If 'cuda', the
+            computation will be done on the GPU if available.
         n_jobs: integer, optional (default = 1)
             The number of CPUs to use to do the computation. -1 means
             'all CPUs', -2 'all CPUs but one', and so on.

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -274,7 +274,11 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
         self.n_pieces = self.parcel_masker.n_pieces
 
         subjects_data = [
-            torch.Tensor(self.masker.transform(img), device=self.device)
+            torch.Tensor(
+                self.masker.transform(img),
+                device=self.device,
+                dtype=torch.float32,
+            )
             for img in imgs
         ]
         sparsity_mask = _create_sparse_cluster_matrix(self.labels_)
@@ -342,7 +346,11 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
             alignment_estimator.fit(img, self.template)
             return alignment_estimator.transform(img)
         else:
-            X = torch.tensor(self.masker.transform(img), device=self.device)
+            X = torch.tensor(
+                self.masker.transform(img),
+                device=self.device,
+                dtype=torch.float32,
+            )
             sparse_estimator = self.fit_[subject_index]
             X_transformed = sparse_estimator.transform(X).cpu().numpy()
             return self.masker.inverse_transform(X_transformed)

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -7,7 +7,6 @@ from sklearn.utils.validation import check_is_fitted
 
 from fmralign._utils import (
     _create_sparse_cluster_matrix,
-    _parcels_to_array,
 )
 from fmralign.alignment_methods import SparseUOT
 from fmralign.preprocessing import ParcellationMasker

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -241,7 +241,7 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
         self.n_pieces = self.parcel_masker.n_pieces
 
         subjects_data = [
-            torch.Tensor(
+            torch.tensor(
                 self.masker.transform(img),
                 device=self.device,
                 dtype=torch.float32,

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -6,7 +6,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from fmralign._utils import (
-    _create_sparse_cluster_matrix,
+    _sparse_cluster_matrix,
 )
 from fmralign.alignment_methods import SparseUOT
 from fmralign.preprocessing import ParcellationMasker
@@ -249,7 +249,7 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
             )
             for img in imgs
         ]
-        sparsity_mask = _create_sparse_cluster_matrix(self.labels_).to(
+        sparsity_mask = _sparse_cluster_matrix(self.labels_).to(
             self.device
         )
         template_data, self.fit_ = _fit_sparse_template(

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -48,13 +48,15 @@ def _fit_sparse_template(
     alignment_method="sparse_uot",
     n_iter=2,
     scale_template=False,
+    verbose=False,
     **kwargs,
 ):
     n_subjects = len(subjects_data)
     if alignment_method != "sparse_uot":
         raise ValueError(f"Unknown alignment method: {alignment_method}")
     subjects_estimators = [
-        SparseUOT(sparsity_mask, **kwargs) for _ in range(n_subjects)
+        SparseUOT(sparsity_mask, verbose=verbose, **kwargs)
+        for _ in range(n_subjects)
     ]
     for _ in range(n_iter):
         template = _rescaled_euclidean_mean_torch(
@@ -249,9 +251,7 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
             )
             for img in imgs
         ]
-        sparsity_mask = _sparse_cluster_matrix(self.labels_).to(
-            self.device
-        )
+        sparsity_mask = _sparse_cluster_matrix(self.labels_).to(self.device)
         template_data, self.fit_ = _fit_sparse_template(
             subjects_data=subjects_data,
             sparsity_mask=sparsity_mask,
@@ -259,6 +259,7 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
             scale_template=self.scale_template,
             alignment_method=self.alignment_method,
             device=self.device,
+            verbose=True if self.verbose > 0 else False,
             **self.kwargs,
         )
 

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -101,13 +101,14 @@ def _fit_sparse_template(
 
     Returns
     -------
-    _type_
-        _description_
+    Tuple[torch.Tensor, List[alignment_methods.Alignment]]
+        Template data and list of alignment estimators
+        from the subjects data to the template.
 
     Raises
     ------
     ValueError
-        _description_
+        Unknown alignment method.
     """
     n_subjects = len(subjects_data)
     if alignment_method != "sparse_uot":

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -99,6 +99,7 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
         device="cpu",
         n_jobs=1,
         verbose=0,
+        **kwargs,
     ):
         """
         Parameters
@@ -194,6 +195,7 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
         self.memory_level = memory_level
         self.n_jobs = n_jobs
         self.verbose = verbose
+        self.kwargs = kwargs
 
     def fit(self, imgs):
         """
@@ -248,13 +250,17 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
             )
             for img in imgs
         ]
-        sparsity_mask = _create_sparse_cluster_matrix(self.labels_)
+        sparsity_mask = _create_sparse_cluster_matrix(self.labels_).to(
+            self.device
+        )
         template_data, self.fit_ = _fit_sparse_template(
             subjects_data=subjects_data,
             sparsity_mask=sparsity_mask,
             n_iter=self.n_iter,
             scale_template=self.scale_template,
             alignment_method=self.alignment_method,
+            device=self.device,
+            **self.kwargs,
         )
 
         self.template_img = self.masker.inverse_transform(

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -1,15 +1,13 @@
 """Module for sparse template alignment."""
 
-import numpy as np
 import torch
-from joblib import Memory, Parallel, delayed
-from sklearn.base import BaseEstimator, TransformerMixin, clone
+from joblib import Memory
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from fmralign._utils import (
     _create_sparse_cluster_matrix,
     _parcels_to_array,
-    _transform_one_img,
 )
 from fmralign.alignment_methods import SparseUOT
 from fmralign.preprocessing import ParcellationMasker

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -1,0 +1,380 @@
+"""Module for sparse template alignment."""
+
+import numpy as np
+import torch
+from joblib import Memory, Parallel, delayed
+from sklearn.base import BaseEstimator, TransformerMixin, clone
+from sklearn.utils.validation import check_is_fitted
+
+from fmralign._utils import (
+    _create_sparse_cluster_matrix,
+    _parcels_to_array,
+    _transform_one_img,
+)
+from fmralign.alignment_methods import SparseUOT
+from fmralign.preprocessing import ParcellationMasker
+from fmralign.sparse_pairwise_alignment import SparsePairwiseAlignment
+
+
+def _rescaled_euclidean_mean_torch(subjects_data, scale_average=False):
+    average_data = torch.mean(subjects_data, dim=0)
+    scale = 1
+    if scale_average:
+        X_norm = 0
+        for data in subjects_data:
+            X_norm += torch.linalg.norm(data)
+        X_norm /= len(subjects_data)
+        scale = X_norm / torch.linalg.norm(average_data)
+    average_data *= scale
+
+    return average_data
+
+
+def _reconstruct_template(fit, labels, masker):
+    """
+    Reconstruct template from fit output.
+
+    Parameters
+    ----------
+    fit: list of list of numpy.ndarray
+        Each element of the list is the list of parcels data for one subject.
+    labels: numpy.ndarray
+        Labels of the parcels.
+    masker: instance of NiftiMasker or MultiNiftiMasker
+        Masker to be used on the data.
+
+    Returns
+    -------
+    template_img: 4D Niimg object
+        Models the barycenter of input imgs
+    template_history: list of 4D Niimgs
+        List of the intermediate templates computed at the end of each iteration
+    """
+    template_parcels = [fit_i["template_data"] for fit_i in fit]
+    template_data = _parcels_to_array(template_parcels, labels)
+    template_img = masker.inverse_transform(template_data)
+
+    n_iter = len(fit[0]["template_history"])
+    template_history = []
+    for i in range(n_iter):
+        template_parcels = [fit_j["template_history"][i] for fit_j in fit]
+        template_data = _parcels_to_array(template_parcels, labels)
+        template_history.append(masker.inverse_transform(template_data))
+
+    return template_img, template_history
+
+
+def _align_images_to_template(
+    subjects_data,
+    template,
+    subjects_estimators,
+):
+    aligned_data = []
+    for i, subject_data in enumerate(subjects_data):
+        sparse_estimator = subjects_estimators[i]
+        sparse_estimator.fit(template, subject_data)
+        aligned_data.append(sparse_estimator.transform(subject_data))
+        # Update the estimator in the list
+        subjects_estimators[i] = sparse_estimator
+    return aligned_data, subjects_estimators
+
+
+def _fit_sparse_template(
+    subjects_data,
+    sparsity_mask,
+    alignment_method="sparse_uot",
+    n_iter=2,
+    scale_template=False,
+    **kwargs,
+):
+    aligned_data = subjects_data
+    n_subjects = len(subjects_data)
+    if alignment_method != "sparse_uot":
+        raise ValueError(f"Unknown alignment method: {alignment_method}")
+    subjects_estimators = [
+        SparseUOT(sparsity_mask, **kwargs) for _ in range(n_subjects)
+    ]
+    for _ in range(n_iter):
+        template = _rescaled_euclidean_mean_torch(aligned_data, scale_template)
+        aligned_data, subjects_estimators = _align_images_to_template(
+            subjects_data,
+            template,
+            subjects_estimators,
+        )
+
+    return template, subjects_estimators
+
+
+class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
+    """
+    Decompose the source images into regions and summarize subjects information
+    in a template, then use pairwise alignment to predict
+    new contrast for target subject.
+    """
+
+    def __init__(
+        self,
+        alignment_method="sparse_uot",
+        n_pieces=1,
+        clustering="kmeans",
+        scale_template=False,
+        n_iter=2,
+        save_template=None,
+        mask=None,
+        smoothing_fwhm=None,
+        standardize=False,
+        detrend=None,
+        target_affine=None,
+        target_shape=None,
+        low_pass=None,
+        high_pass=None,
+        t_r=None,
+        memory=Memory(location=None),
+        memory_level=0,
+        device="cpu",
+        n_jobs=1,
+        verbose=0,
+    ):
+        """
+        Parameters
+        ----------
+        alignment_method: string
+            Algorithm used to perform alignment between X_i and Y_i :
+            * either 'identity', 'scaled_orthogonal', 'optimal_transport',
+            'ridge_cv', 'permutation', 'diagonal',
+            * or an instance of one of alignment classes (imported from
+            fmralign.alignment_methods)
+        n_pieces: int, optional (default = 1)
+            Number of regions in which the data is parcellated for alignment.
+            If 1 the alignment is done on full scale data.
+            If > 1, the voxels are clustered and alignment is performed on each
+            cluster applied to X and Y.
+        clustering : string or 3D Niimg optional (default : kmeans)
+            'kmeans', 'ward', 'rena', 'hierarchical_kmeans' method used for
+            clustering of voxels based on functional signal,
+            passed to nilearn.regions.parcellations
+            If 3D Niimg, image used as predefined clustering,
+            n_pieces is then ignored.
+        scale_template: boolean, default False
+            rescale template after each inference so that it keeps
+            the same norm as the average of training images.
+        n_iter: int
+           number of iteration in the alternate minimization. Each img is
+           aligned n_iter times to the evolving template. If n_iter = 0,
+           the template is simply the mean of the input images.
+        save_template: None or string(optional)
+            If not None, path to which the template will be saved.
+        mask: Niimg-like object, instance of NiftiMasker or
+                                MultiNiftiMasker, optional (default = None)
+            Mask to be used on data. If an instance of masker is passed, then its
+            mask will be used. If no mask is given, it will be computed
+            automatically by a MultiNiftiMasker with default parameters.
+        smoothing_fwhm: float, optional (default = None)
+            If smoothing_fwhm is not None, it gives the size in millimeters
+            of the spatial smoothing to apply to the signal.
+        standardize: boolean, optional (default = None)
+            If standardize is True, the time-series are centered and normed:
+            their variance is put to 1 in the time dimension.
+        detrend: boolean, optional (default = None)
+            This parameter is passed to nilearn.signal.clean.
+            Please see the related documentation for details
+        target_affine: 3x3 or 4x4 matrix, optional (default = None)
+            This parameter is passed to nilearn.image.resample_img.
+            Please see the related documentation for details.
+        target_shape: 3-tuple of integers, optional (default = None)
+            This parameter is passed to nilearn.image.resample_img.
+            Please see the related documentation for details.
+        low_pass: None or float, optional (default = None)
+            This parameter is passed to nilearn.signal.clean.
+            Please see the related documentation for details.
+        high_pass: None or float, optional (default = None)
+            This parameter is passed to nilearn.signal.clean.
+            Please see the related documentation for details.
+        t_r: float, optional (default = None)
+            This parameter is passed to nilearn.signal.clean.
+            Please see the related documentation for details.
+        memory: instance of joblib.Memory or string (default = None)
+            Used to cache the masking process and results of algorithms.
+            By default, no caching is done. If a string is given, it is the
+            path to the caching directory.
+        memory_level: integer, optional (default = None)
+            Rough estimator of the amount of memory used by caching.
+            Higher value means more memory for caching.
+        n_jobs: integer, optional (default = 1)
+            The number of CPUs to use to do the computation. -1 means
+            'all CPUs', -2 'all CPUs but one', and so on.
+        verbose: integer, optional (default = 0)
+            Indicate the level of verbosity. By default, nothing is printed.
+
+        """
+        self.template = None
+        self.template_history = None
+        self.alignment_method = alignment_method
+        self.n_pieces = n_pieces
+        self.clustering = clustering
+        self.n_iter = n_iter
+        self.scale_template = scale_template
+        self.save_template = save_template
+        self.mask = mask
+        self.smoothing_fwhm = smoothing_fwhm
+        self.standardize = standardize
+        self.detrend = detrend
+        self.target_affine = target_affine
+        self.target_shape = target_shape
+        self.low_pass = low_pass
+        self.high_pass = high_pass
+        self.t_r = t_r
+        self.device = device
+        self.memory = memory
+        self.memory_level = memory_level
+        self.n_jobs = n_jobs
+        self.verbose = verbose
+
+    def fit(self, imgs):
+        """
+        Learn a template from source images, using alignment.
+
+        Parameters
+        ----------
+        imgs: List of 4D Niimg-like or List of lists of 3D Niimg-like
+            Source subjects data. Each element of the parent list is one subject
+            data, and all must have the same length (n_samples).
+
+        Returns
+        -------
+        self
+
+        Attributes
+        ----------
+        self.template: 4D Niimg object
+            Length : n_samples
+
+        """
+
+        self.parcel_masker = ParcellationMasker(
+            n_pieces=self.n_pieces,
+            clustering=self.clustering,
+            mask=self.mask,
+            smoothing_fwhm=self.smoothing_fwhm,
+            standardize=self.standardize,
+            detrend=self.detrend,
+            low_pass=self.low_pass,
+            high_pass=self.high_pass,
+            t_r=self.t_r,
+            target_affine=self.target_affine,
+            target_shape=self.target_shape,
+            memory=self.memory,
+            memory_level=self.memory_level,
+            n_jobs=self.n_jobs,
+            verbose=self.verbose,
+        )
+
+        self.parcel_masker.fit(imgs)
+        self.masker = self.parcel_masker.masker_
+        self.mask = self.parcel_masker.masker_.mask_img_
+        self.labels_ = self.parcel_masker.labels
+        self.n_pieces = self.parcel_masker.n_pieces
+
+        subjects_data = [
+            torch.Tensor(self.masker.transform(img), device=self.device)
+            for img in imgs
+        ]
+        sparsity_mask = _create_sparse_cluster_matrix(self.labels_)
+        template_data, self.fit_ = _fit_sparse_template(
+            subjects_data=subjects_data,
+            sparsity_mask=sparsity_mask,
+            n_iter=self.n_iter,
+            scale_template=self.scale_template,
+            alignment_method=self.alignment_method,
+        )
+
+        self.template_img = self.masker.inverse_transform(
+            template_data.cpu().numpy()
+        )
+        if self.save_template is not None:
+            self.template.to_filename(self.save_template)
+
+    def transform(self, img, subject_index=None):
+        """
+        Transform a (new) subject image into the template space.
+
+        Parameters
+        ----------
+        img: 4D Niimg-like object
+            Subject image.
+        subject_index: int, optional (default = None)
+            Index of the subject to be transformed. It should
+            correspond to the index of the subject in the list of
+            subjects used to fit the template. If None, a new
+            `PairwiseAlignment` object is fitted between the new
+            subject and the template before transforming.
+
+
+        Returns
+        -------
+        predicted_imgs: 4D Niimg object
+            Transformed data.
+
+        """
+        if not hasattr(self, "fit_"):
+            raise ValueError(
+                "This instance has not been fitted yet. "
+                "Please call 'fit' before 'transform'."
+            )
+
+        if subject_index is None:
+            alignment_estimator = SparsePairwiseAlignment(
+                n_pieces=self.n_pieces,
+                alignment_method=self.alignment_method,
+                clustering=self.parcel_masker.get_parcellation_img(),
+                mask=self.masker,
+                smoothing_fwhm=self.smoothing_fwhm,
+                standardize=self.standardize,
+                detrend=self.detrend,
+                target_affine=self.target_affine,
+                target_shape=self.target_shape,
+                low_pass=self.low_pass,
+                high_pass=self.high_pass,
+                t_r=self.t_r,
+                memory=self.memory,
+                memory_level=self.memory_level,
+                n_jobs=self.n_jobs,
+                verbose=self.verbose,
+            )
+            alignment_estimator.fit(img, self.template)
+            return alignment_estimator.transform(img)
+        else:
+            X = torch.tensor(self.masker.transform(img), device=self.device)
+            sparse_estimator = self.fit_[subject_index]
+            X_transformed = sparse_estimator.transform(X).cpu().numpy()
+            return self.masker.inverse_transform(X_transformed)
+
+    # Make inherited function harmless
+    def fit_transform(self):
+        """Parent method not applicable here. Will raise AttributeError if called."""
+        raise AttributeError(
+            "type object 'PairwiseAlignment' has no attribute 'fit_transform'"
+        )
+
+    def get_parcellation(self):
+        """Get the parcellation masker used for alignment.
+
+        Returns
+        -------
+        labels: `list` of `int`
+            Labels of the parcellation masker.
+        parcellation_img: Niimg-like object
+            Parcellation image.
+        """
+        if hasattr(self, "parcel_masker"):
+            check_is_fitted(self)
+            labels = self.parcel_masker.get_labels()
+            parcellation_img = self.parcel_masker.get_parcellation_img()
+            return labels, parcellation_img
+        else:
+            raise AttributeError(
+                (
+                    "Parcellation has not been computed yet,"
+                    "please fit the alignment estimator first."
+                )
+            )

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -66,7 +66,7 @@ def _align_images_to_template(
     n_subjects = len(subjects_data)
     for i in range(n_subjects):
         sparse_estimator = subjects_estimators[i]
-        sparse_estimator.fit(template, subjects_data[i])
+        sparse_estimator.fit(subjects_data[i], template)
         subjects_data[i] = sparse_estimator.transform(subjects_data[i])
         # Update the estimator in the list
         subjects_estimators[i] = sparse_estimator

--- a/fmralign/tests/test_alignment_methods.py
+++ b/fmralign/tests/test_alignment_methods.py
@@ -199,23 +199,24 @@ def test_all_classes_R_and_pred_shape_and_better_than_identity():
 
 def test_ot_backend():
     n_samples, n_features = 100, 20
+    epsilon = 1e-2
     X = np.random.randn(n_samples, n_features)
     Y = np.random.randn(n_samples, n_features)
     X /= np.linalg.norm(X)
     Y /= np.linalg.norm(Y)
-    ott_algo = OptimalTransportAlignment()
-    pot_algo = POTAlignment()
+    ott_algo = OptimalTransportAlignment(reg=epsilon)
+    pot_algo = POTAlignment(reg=epsilon)
     sparsity_mask = torch.ones(n_features, n_features).to_sparse_coo()
-    torch_algo = SparseUOT(sparsity_mask=sparsity_mask)
+    torch_algo = SparseUOT(sparsity_mask=sparsity_mask, reg=epsilon)
     ott_algo.fit(X, Y)
     pot_algo.fit(X, Y)
     torch_algo.fit(
         torch.tensor(X, dtype=torch.float32),
         torch.tensor(Y, dtype=torch.float32),
     )
-    assert_array_almost_equal(pot_algo.R, ott_algo.R, decimal=2)
+    assert_array_almost_equal(pot_algo.R, ott_algo.R, decimal=3)
     assert_array_almost_equal(
-        ott_algo.R, torch_algo.R.to_dense().numpy(), decimal=2
+        pot_algo.R, torch_algo.R.to_dense().numpy(), decimal=3
     )
 
 
@@ -237,8 +238,8 @@ def test_regularization_effect():
     Y = np.random.randn(n_samples, n_features)
 
     # Compare results with different regularization values
-    algo1 = OptimalTransportAlignment(reg=1e-1, tau=1.0, metric="euclidean")
-    algo2 = OptimalTransportAlignment(reg=1e-3, tau=1.0, metric="euclidean")
+    algo1 = OptimalTransportAlignment(reg=1e-1, tau=1.0)
+    algo2 = OptimalTransportAlignment(reg=1e-3, tau=1.0)
 
     algo1.fit(X, Y)
     algo2.fit(X, Y)

--- a/fmralign/tests/test_alignment_methods.py
+++ b/fmralign/tests/test_alignment_methods.py
@@ -197,30 +197,25 @@ def test_all_classes_R_and_pred_shape_and_better_than_identity():
             assert algo_score >= identity_baseline_score
 
 
-def test_ott_backend():
+def test_ot_backend():
     n_samples, n_features = 100, 20
-    epsilon = 0.1
     X = np.random.randn(n_samples, n_features)
     Y = np.random.randn(n_samples, n_features)
-    ott_algo = OptimalTransportAlignment(
-        reg=epsilon, metric="euclidean", tol=1e-5, max_iter=10000
-    )
-    pot_algo = POTAlignment(
-        reg=epsilon, metric="euclidean", tol=1e-5, max_iter=10000
-    )
+    X /= np.linalg.norm(X)
+    Y /= np.linalg.norm(Y)
+    ott_algo = OptimalTransportAlignment()
+    pot_algo = POTAlignment()
     sparsity_mask = torch.ones(n_features, n_features).to_sparse_coo()
-    torch_algo = SparseUOT(
-        sparsity_mask=sparsity_mask, reg=epsilon, tol=1e-5, max_iter=10000
-    )
+    torch_algo = SparseUOT(sparsity_mask=sparsity_mask)
     ott_algo.fit(X, Y)
     pot_algo.fit(X, Y)
     torch_algo.fit(
         torch.tensor(X, dtype=torch.float32),
         torch.tensor(Y, dtype=torch.float32),
     )
-    assert_array_almost_equal(ott_algo.R, pot_algo.R, decimal=3)
+    assert_array_almost_equal(pot_algo.R, ott_algo.R, decimal=2)
     assert_array_almost_equal(
-        ott_algo.R, torch_algo.pi.to_dense().numpy() * n_features, decimal=3
+        ott_algo.R, torch_algo.R.to_dense().numpy(), decimal=2
     )
 
 

--- a/fmralign/tests/test_alignment_methods.py
+++ b/fmralign/tests/test_alignment_methods.py
@@ -8,7 +8,6 @@ from scipy.sparse import csc_matrix
 
 from fmralign.alignment_methods import (
     DiagonalAlignment,
-    FugwAlignment,
     Hungarian,
     Identity,
     OptimalTransportAlignment,
@@ -195,22 +194,6 @@ def test_all_classes_R_and_pred_shape_and_better_than_identity():
             assert X_pred.shape == X.shape
             algo_score = zero_mean_coefficient_determination(Y, X_pred)
             assert algo_score >= identity_baseline_score
-
-
-@pytest.mark.skip_if_no_mkl
-@pytest.mark.parametrize("method", ["dense", "coarse-to-fine"])
-def test_fugw_alignment(method):
-    # Create a fake segmentation
-    segmentation = np.ones((10, 10, 10))
-    n_features = 3
-    n_samples = int(segmentation.sum())
-    X = np.random.randn(n_samples, n_features).T
-    Y = np.random.randn(n_samples, n_features).T
-
-    fugw_alignment = FugwAlignment(segmentation, method=method)
-    fugw_alignment.fit(X, Y)
-    assert fugw_alignment.transform(X).shape == X.shape
-    assert fugw_alignment.transform(X).shape == Y.shape
 
 
 def test_ott_backend():

--- a/fmralign/tests/test_alignment_methods.py
+++ b/fmralign/tests/test_alignment_methods.py
@@ -242,8 +242,8 @@ def test_regularization_effect():
     Y = np.random.randn(n_samples, n_features)
 
     # Compare results with different regularization values
-    algo1 = OptimalTransportAlignment(reg=1e-1, tau=1.0)
-    algo2 = OptimalTransportAlignment(reg=1e-3, tau=1.0)
+    algo1 = OptimalTransportAlignment(reg=1e-1, tau=1.0, metric="euclidean")
+    algo2 = OptimalTransportAlignment(reg=1e-3, tau=1.0, metric="euclidean")
 
     algo1.fit(X, Y)
     algo2.fit(X, Y)

--- a/fmralign/tests/test_alignment_methods.py
+++ b/fmralign/tests/test_alignment_methods.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pytest
 from numpy.testing import assert_array_almost_equal
 from scipy.linalg import orthogonal_procrustes
 from scipy.sparse import csc_matrix

--- a/fmralign/tests/test_sparse_pairwise_alignment.py
+++ b/fmralign/tests/test_sparse_pairwise_alignment.py
@@ -9,7 +9,6 @@ from fmralign.tests.utils import (
 )
 import torch
 import pytest
-from itertools import product
 
 devices = [torch.device("cpu")]
 if torch.cuda.is_available():
@@ -17,15 +16,10 @@ if torch.cuda.is_available():
 
 
 @pytest.mark.skip_if_no_mkl
-@pytest.mark.parametrize(
-    "solver,device",
-    product(["sinkhorn", "mm", "mm_l2", "ibpp"], devices),
-)
-def test_sparse_solvers(solver, device):
+@pytest.mark.parametrize("device", devices)
+def test_fit_method(device):
     """Test various solvers for SparsePairwiseAlignment"""
-    alignment = SparsePairwiseAlignment(
-        n_pieces=3, solver=solver, device=device
-    )
+    alignment = SparsePairwiseAlignment(n_pieces=3, device=device)
     img1, _ = random_niimg((8, 7, 6, 10))
     img2, _ = random_niimg((8, 7, 6, 10))
     alignment.fit(img1, img2)
@@ -33,15 +27,10 @@ def test_sparse_solvers(solver, device):
 
 
 @pytest.mark.skip_if_no_mkl
-@pytest.mark.parametrize(
-    "solver,device",
-    product(["sinkhorn", "mm", "mm_l2", "ibpp"], devices),
-)
-def test_identity_alignment(solver, device):
+@pytest.mark.parametrize("device", devices)
+def test_identity_alignment(device):
     """Test the identity alignment for SparsePairwiseAlignment"""
-    alignment = SparsePairwiseAlignment(
-        solver=solver, device=device, reg=1e-6, tol=1e-10
-    )
+    alignment = SparsePairwiseAlignment(device=device, reg=1e-6, tol=1e-10)
     img, _ = random_niimg((8, 7, 6, 100))
     alignment.fit(img, img)
     img_transformed = alignment.transform(img)

--- a/fmralign/tests/test_sparse_pairwise_alignment.py
+++ b/fmralign/tests/test_sparse_pairwise_alignment.py
@@ -30,12 +30,14 @@ def test_fit_method(device):
 @pytest.mark.parametrize("device", devices)
 def test_identity_alignment(device):
     """Test the identity alignment for SparsePairwiseAlignment"""
-    alignment = SparsePairwiseAlignment(device=device, reg=1e-6, tol=1e-10)
+    alignment = SparsePairwiseAlignment(device=device, reg=1e-4)
     img, _ = random_niimg((8, 7, 6, 100))
     alignment.fit(img, img)
+    masker = alignment.masker
     img_transformed = alignment.transform(img)
-    assert img_transformed.shape == img.shape
-    assert isinstance(img_transformed, Nifti1Image)
+    data = masker.transform(img)
+    data_transformed = masker.transform(img_transformed)
+    assert np.allclose(data, data_transformed, atol=1e-5)
 
 
 @pytest.mark.skip_if_no_mkl

--- a/fmralign/tests/test_sparse_pairwise_alignment.py
+++ b/fmralign/tests/test_sparse_pairwise_alignment.py
@@ -36,10 +36,6 @@ def test_identity_alignment(device):
     img_transformed = alignment.transform(img)
     assert img_transformed.shape == img.shape
     assert isinstance(img_transformed, Nifti1Image)
-    masker = alignment.masker
-    assert np.allclose(
-        masker.transform(img), masker.transform(img_transformed)
-    )
 
 
 @pytest.mark.skip_if_no_mkl

--- a/fmralign/tests/test_sparse_pairwise_alignment.py
+++ b/fmralign/tests/test_sparse_pairwise_alignment.py
@@ -80,6 +80,7 @@ def test_surface_alignment(device):
     assert isinstance(parcellation_image, SurfaceImage)
 
 
+@pytest.mark.skip_if_no_mkl
 def test_parcellation_retrieval():
     """Test that SparsePairwiseAlignment returns both the\n
     labels and the parcellation image"""
@@ -96,6 +97,7 @@ def test_parcellation_retrieval():
     assert parcellation_image.shape == img1.shape
 
 
+@pytest.mark.skip_if_no_mkl
 def test_parcellation_before_fit():
     """Test that SparsePairwiseAlignment raises an error if\n
     the parcellation is retrieved before fitting"""
@@ -104,7 +106,3 @@ def test_parcellation_before_fit():
         AttributeError, match="Parcellation has not been computed yet"
     ):
         alignment.get_parcellation()
-
-
-if __name__ == "__main__":
-    test_identity_alignment("ibpp", torch.device("cpu"))

--- a/fmralign/tests/test_sparse_pairwise_alignment.py
+++ b/fmralign/tests/test_sparse_pairwise_alignment.py
@@ -1,0 +1,47 @@
+import numpy as np
+from nibabel.nifti1 import Nifti1Image
+from nilearn.surface import SurfaceImage
+
+from fmralign.sparse_pairwise_alignment import SparsePairwiseAlignment
+from fmralign.tests.utils import (
+    random_niimg,
+    surf_img,
+)
+
+
+def test_surface_alignment():
+    """Test compatibility with `SurfaceImage`"""
+    n_pieces = 3
+    img1 = surf_img(20)
+    img2 = surf_img(20)
+    alignment = SparsePairwiseAlignment(n_pieces=n_pieces)
+
+    # Test fitting
+    alignment.fit(img1, img2)
+
+    # Test transformation
+    img_transformed = alignment.transform(img1)
+    assert img_transformed.shape == img1.shape
+    assert isinstance(img_transformed, SurfaceImage)
+
+    # Test parcellation retrieval
+    labels, parcellation_image = alignment.get_parcellation()
+    assert isinstance(labels, np.ndarray)
+    assert len(np.unique(labels)) == n_pieces
+    assert isinstance(parcellation_image, SurfaceImage)
+
+
+def test_parcellation_retrieval():
+    """Test that PairwiseAlignment returns both the\n
+    labels and the parcellation image"""
+    n_pieces = 3
+    img1, _ = random_niimg((8, 7, 6))
+    img2, _ = random_niimg((8, 7, 6))
+    alignment = SparsePairwiseAlignment(n_pieces=n_pieces)
+    alignment.fit(img1, img2)
+
+    labels, parcellation_image = alignment.get_parcellation()
+    assert isinstance(labels, np.ndarray)
+    assert len(np.unique(labels)) == n_pieces
+    assert isinstance(parcellation_image, Nifti1Image)
+    assert parcellation_image.shape == img1.shape

--- a/fmralign/tests/test_sparse_pairwise_alignment.py
+++ b/fmralign/tests/test_sparse_pairwise_alignment.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+import torch
 from nibabel.nifti1 import Nifti1Image
 from nilearn.surface import SurfaceImage
 
@@ -7,8 +9,6 @@ from fmralign.tests.utils import (
     random_niimg,
     surf_img,
 )
-import torch
-import pytest
 
 devices = [torch.device("cpu")]
 if torch.cuda.is_available():

--- a/fmralign/tests/test_sparse_template_alignment.py
+++ b/fmralign/tests/test_sparse_template_alignment.py
@@ -5,16 +5,15 @@ import pytest
 import torch
 from nibabel.nifti1 import Nifti1Image
 
-from fmralign.alignment_methods import SparseUOT
+from fmralign.alignment_methods import POTAlignment, SparseUOT
 from fmralign.sparse_template_alignment import (
     SparseTemplateAlignment,
     _align_images_to_template,
     _fit_sparse_template,
     _rescaled_euclidean_mean_torch,
 )
-from fmralign.tests.utils import random_niimg, sample_subjects_data
 from fmralign.template_alignment import TemplateAlignment
-from fmralign.alignment_methods import POTAlignment
+from fmralign.tests.utils import random_niimg, sample_subjects_data
 
 devices = [torch.device("cpu")]
 if torch.cuda.is_available():

--- a/fmralign/tests/test_sparse_template_alignment.py
+++ b/fmralign/tests/test_sparse_template_alignment.py
@@ -25,6 +25,8 @@ if torch.cuda.is_available():
     "scale_average, device", product([True, False], devices)
 )
 def test_rescaled_euclidean_mean_torch(scale_average, device):
+    """Test that _rescaled_euclidean_mean_torch returns a tensor\n
+    with the same shape and dtype as the input tensors"""
     subjects_data_np = sample_subjects_data()
     subjects_data = [
         torch.tensor(data, device=device, dtype=torch.float32)
@@ -42,6 +44,8 @@ def test_rescaled_euclidean_mean_torch(scale_average, device):
 @pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize("device", devices)
 def test_align_images_to_template(device):
+    """Test that _align_images_to_template returns a list of\n
+    aligned data and a list of estimators"""
     subjects_data_np = sample_subjects_data()
     subjects_data = [
         torch.tensor(data, device=device, dtype=torch.float32)
@@ -68,6 +72,8 @@ def test_align_images_to_template(device):
 @pytest.mark.skip_if_no_mkl
 @pytest.mark.parametrize("device", devices)
 def test_fit_sparse_template(device):
+    """Test that _fit_sparse_template returns a template and\n
+    a list of AlignmentEstimator objects"""
     subjects_data_np = sample_subjects_data()
     subjects_data = [
         torch.tensor(data, device=device, dtype=torch.float32)

--- a/fmralign/tests/test_sparse_template_alignment.py
+++ b/fmralign/tests/test_sparse_template_alignment.py
@@ -1,16 +1,18 @@
-import torch
+from itertools import product
+
 import numpy as np
 import pytest
+import torch
+from nibabel.nifti1 import Nifti1Image
+
+from fmralign.alignment_methods import SparseUOT
 from fmralign.sparse_template_alignment import (
-    _rescaled_euclidean_mean_torch,
+    SparseTemplateAlignment,
     _align_images_to_template,
     _fit_sparse_template,
+    _rescaled_euclidean_mean_torch,
 )
-from nibabel.nifti1 import Nifti1Image
-from fmralign.tests.utils import sample_subjects_data, random_niimg
-from itertools import product
-from fmralign.alignment_methods import SparseUOT
-from fmralign.sparse_template_alignment import SparseTemplateAlignment
+from fmralign.tests.utils import random_niimg, sample_subjects_data
 
 devices = [torch.device("cpu")]
 if torch.cuda.is_available():

--- a/fmralign/tests/test_sparse_template_alignment.py
+++ b/fmralign/tests/test_sparse_template_alignment.py
@@ -1,0 +1,115 @@
+import torch
+import numpy as np
+import pytest
+from fmralign.sparse_template_alignment import (
+    _rescaled_euclidean_mean_torch,
+    _align_images_to_template,
+    _fit_sparse_template,
+)
+from nibabel.nifti1 import Nifti1Image
+from fmralign.tests.utils import sample_subjects_data, random_niimg
+from itertools import product
+from fmralign.alignment_methods import SparseUOT
+from fmralign.sparse_template_alignment import SparseTemplateAlignment
+
+devices = [torch.device("cpu")]
+if torch.cuda.is_available():
+    devices.append(torch.device("cuda:0"))
+
+
+@pytest.mark.skip_if_no_mkl
+@pytest.mark.parametrize(
+    "scale_average, device", product([True, False], devices)
+)
+def test_rescaled_euclidean_mean_torch(scale_average, device):
+    subjects_data_np = sample_subjects_data()
+    subjects_data = [
+        torch.tensor(data, device=device, dtype=torch.float32)
+        for data in subjects_data_np
+    ]
+    average_data = _rescaled_euclidean_mean_torch(subjects_data)
+    assert average_data.shape == subjects_data[0].shape
+    assert average_data.dtype == subjects_data[0].dtype
+
+    if scale_average is False:
+        euclidean_mean = torch.mean(torch.stack(subjects_data), dim=0)
+        assert torch.allclose(average_data, euclidean_mean)
+
+
+@pytest.mark.skip_if_no_mkl
+@pytest.mark.parametrize("device", devices)
+def test_align_images_to_template(device):
+    subjects_data_np = sample_subjects_data()
+    subjects_data = [
+        torch.tensor(data, device=device, dtype=torch.float32)
+        for data in subjects_data_np
+    ]
+    sparsity_mask = torch.eye(
+        subjects_data[0].shape[0], device=device
+    ).to_sparse_coo()
+    subjects_estimators = [
+        SparseUOT(sparsity_mask, device=device)
+        for _ in range(len(subjects_data))
+    ]
+    template = _rescaled_euclidean_mean_torch(subjects_data)
+    aligned_data, subjects_estimators = _align_images_to_template(
+        subjects_data,
+        template,
+        subjects_estimators,
+    )
+    assert len(aligned_data) == len(subjects_data)
+    assert len(subjects_estimators) == len(subjects_data)
+    assert aligned_data[0].shape == subjects_data[0].shape
+
+
+@pytest.mark.skip_if_no_mkl
+@pytest.mark.parametrize("device", devices)
+def test_fit_sparse_template(device):
+    subjects_data_np = sample_subjects_data()
+    subjects_data = [
+        torch.tensor(data, device=device, dtype=torch.float32)
+        for data in subjects_data_np
+    ]
+    sparsity_mask = torch.eye(
+        subjects_data[0].shape[0], device=device
+    ).to_sparse_coo()
+    template, subjects_estimators = _fit_sparse_template(
+        subjects_data,
+        sparsity_mask,
+        device=device,
+    )
+    assert template.shape == subjects_data[0].shape
+    assert len(subjects_estimators) == len(subjects_data)
+    assert template.device == device
+    for estimator in subjects_estimators:
+        assert estimator.device == device
+
+
+@pytest.mark.skip_if_no_mkl
+def test_parcellation_retrieval():
+    """Test that SparseTemplateAlignment returns both the\n
+    labels and the parcellation image
+    """
+    n_pieces = 3
+    imgs = [random_niimg((8, 7, 6))[0]] * 3
+    alignment = SparseTemplateAlignment(n_pieces=n_pieces)
+    alignment.fit(imgs)
+
+    labels, parcellation_image = alignment.get_parcellation()
+    assert isinstance(labels, np.ndarray)
+    assert len(np.unique(labels)) == n_pieces
+    assert isinstance(parcellation_image, Nifti1Image)
+    assert parcellation_image.shape == imgs[0].shape[:-1]
+
+
+@pytest.mark.skip_if_no_mkl
+def test_parcellation_before_fit():
+    """Test that SparseTemplateAlignment raises an error if\n
+    the parcellation is retrieved before fitting
+    """
+    alignment = SparseTemplateAlignment()
+    with pytest.raises(
+        AttributeError,
+        match="Parcellation has not been computed yet",
+    ):
+        alignment.get_parcellation()

--- a/fmralign/tests/test_utils.py
+++ b/fmralign/tests/test_utils.py
@@ -4,8 +4,12 @@ import numpy as np
 import pytest
 from nilearn.maskers import NiftiMasker
 from numpy.testing import assert_array_almost_equal, assert_array_equal
-
-from fmralign._utils import ParceledData, _make_parcellation
+import torch
+from fmralign._utils import (
+    ParceledData,
+    _make_parcellation,
+    _sparse_cluster_matrix,
+)
 from fmralign.tests.utils import random_niimg, sample_parceled_data
 
 
@@ -189,3 +193,26 @@ def test_non_contiguous_labels():
     # Test accessing by label
     same_parcel = parceled.get_parcel(1)
     assert_array_equal(same_parcel, expected)
+
+
+def test_sparse_cluster_matrix():
+    labels = torch.tensor([1, 1, 2, 2, 2])
+    sparse_matrix = _sparse_cluster_matrix(labels)
+
+    expected = torch.tensor(
+        [
+            [1, 1, 0, 0, 0],
+            [1, 1, 0, 0, 0],
+            [0, 0, 1, 1, 1],
+            [0, 0, 1, 1, 1],
+            [0, 0, 1, 1, 1],
+        ],
+        dtype=torch.bool,
+    )
+
+    assert sparse_matrix.shape == (5, 5)
+    assert sparse_matrix.dtype == torch.bool
+    assert torch.allclose(sparse_matrix.to_dense(), expected)
+
+
+test_sparse_cluster_matrix()

--- a/fmralign/tests/test_utils.py
+++ b/fmralign/tests/test_utils.py
@@ -197,7 +197,7 @@ def test_non_contiguous_labels():
 
 
 def test_sparse_cluster_matrix():
-    # Test with 2 clusters
+    """Test _sparse_cluster_matrix on 2 clusters."""
     labels = torch.tensor([1, 1, 2, 2, 2])
     sparse_matrix = _sparse_cluster_matrix(labels)
 

--- a/fmralign/tests/test_utils.py
+++ b/fmralign/tests/test_utils.py
@@ -2,9 +2,10 @@
 import nibabel as nib
 import numpy as np
 import pytest
+import torch
 from nilearn.maskers import NiftiMasker
 from numpy.testing import assert_array_almost_equal, assert_array_equal
-import torch
+
 from fmralign._utils import (
     ParceledData,
     _make_parcellation,

--- a/fmralign/tests/test_utils.py
+++ b/fmralign/tests/test_utils.py
@@ -213,6 +213,3 @@ def test_sparse_cluster_matrix():
     assert sparse_matrix.shape == (5, 5)
     assert sparse_matrix.dtype == torch.bool
     assert torch.allclose(sparse_matrix.to_dense(), expected)
-
-
-test_sparse_cluster_matrix()

--- a/fmralign/tests/test_utils.py
+++ b/fmralign/tests/test_utils.py
@@ -197,6 +197,7 @@ def test_non_contiguous_labels():
 
 
 def test_sparse_cluster_matrix():
+    # Test with 2 clusters
     labels = torch.tensor([1, 1, 2, 2, 2])
     sparse_matrix = _sparse_cluster_matrix(labels)
 

--- a/fmralign/tests/utils.py
+++ b/fmralign/tests/utils.py
@@ -44,7 +44,9 @@ def zero_mean_coefficient_determination(
     nonzero_numerator = numerator != 0
     valid_score = nonzero_denominator & nonzero_numerator
     output_scores = np.ones([y_true.shape[1]])
-    output_scores[valid_score] = 1 - (numerator[valid_score] / denominator[valid_score])
+    output_scores[valid_score] = 1 - (
+        numerator[valid_score] / denominator[valid_score]
+    )
     output_scores[nonzero_numerator & ~nonzero_denominator] = 0
 
     if multioutput == "raw_values":
@@ -55,7 +57,8 @@ def zero_mean_coefficient_determination(
         avg_weights = None
     elif multioutput == "variance_weighted":
         avg_weights = (
-            weight * (y_true - np.average(y_true, axis=0, weights=sample_weight)) ** 2
+            weight
+            * (y_true - np.average(y_true, axis=0, weights=sample_weight)) ** 2
         ).sum(axis=0, dtype=np.float64)
         # avoid fail on constant y or one-element arrays
         if not np.any(nonzero_denominator):
@@ -142,7 +145,8 @@ def _make_mesh():
     left_coords = np.asarray([[0.0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
     left_faces = np.asarray([[1, 0, 2], [0, 1, 3], [0, 3, 2], [1, 2, 3]])
     right_coords = (
-        np.asarray([[0.0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0, 0, 1]]) + 2.0
+        np.asarray([[0.0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0, 0, 1]])
+        + 2.0
     )
     right_faces = np.asarray(
         [
@@ -182,4 +186,3 @@ def sample_subjects_data(n_subjects=3):
     """Sample data in one parcel for n_subjects"""
     subjects_data = [np.random.rand(10, 20) for _ in range(n_subjects)]
     return subjects_data
-


### PR DESCRIPTION
Replaces FUGW by hard parcellations constraints to build a sparse transport plan. Enables GPU acceleration with torch for fast pairwise/template estimation.

- [x] Docstrings 
- [x] Pairwise alignment
- [x] Template alignment
- [x] CPU tests
- [x] GPU tests

Usage:
```python
from fmralign.sparse_pairwise_alignment import SparsePairwiseAlignment

alignment = SparsePairwiseAlignment(device=device, reg=1e-2, device="cuda")
alignment.fit(img1, img2)
img1_transformed = alignment.transform(img1)
```