### PR TITLE
[ENH] Refactor masker handling

### DIFF
--- a/doc/functional_alignment/fmralign_pipeline.rst
+++ b/doc/functional_alignment/fmralign_pipeline.rst
@@ -185,7 +185,7 @@ the correlation of this prediction with the real signal. We also include identit
 >>> methods = ['identity','scaled_orthogonal', 'ridge_cv', 'optimal_transport']
 
 >>> for method in methods:
->>>   alignment_estimator = PairwiseAlignment(alignment_method=method, n_pieces=n_pieces, mask=roi_masker)
+>>>   alignment_estimator = PairwiseAlignment(alignment_method=method, n_pieces=n_pieces, masker=roi_masker)
 >>>   alignment_estimator.fit(source_train, target_train)
 >>>   target_pred = alignment_estimator.transform(source_test)
 >>>   aligned_score = voxelwise_correlation(target_test, target_pred, roi_masker)

--- a/doc/functional_alignment/introduction.rst
+++ b/doc/functional_alignment/introduction.rst
@@ -111,7 +111,7 @@ We align the whole brain through multiple local alignment, each applied on a pie
 
 >>> from fmralign.pairwise_alignment import PairwiseAlignment
 >>> alignement_estimator = PairwiseAlignment(alignment_method='scaled_orthogonal',
->>>                                                   n_pieces=150, mask=masker)
+>>>                                                   n_pieces=150, masker=masker)
 
 We learn alignment operator from subject 1 to subject 2 on 'AP' data.
 

--- a/examples/plot_alignment_methods_benchmark.py
+++ b/examples/plot_alignment_methods_benchmark.py
@@ -141,7 +141,7 @@ methods = ["identity", "scaled_orthogonal", "ridge_cv", "optimal_transport"]
 
 for method in methods:
     alignment_estimator = PairwiseAlignment(
-        alignment_method=method, n_pieces=n_pieces, mask=roi_masker
+        alignment_method=method, n_pieces=n_pieces, masker=roi_masker
     )
     alignment_estimator.fit(source_train, target_train)
     target_pred = alignment_estimator.transform(source_test)

--- a/examples/plot_int_alignment.py
+++ b/examples/plot_int_alignment.py
@@ -128,7 +128,7 @@ target_test_masked = np.array(masked_imgs)[:, test_index, :]
 
 
 parcels = compute_parcels(
-    niimg=template_train[0], masker=masker, n_parcels=100, n_jobs=5
+    niimg=template_train[0], mask=masker, n_parcels=100, n_jobs=5
 )
 denoiser = PiecewiseAlignment(n_jobs=5)
 denoised_signal = denoiser.fit_transform(X=denoising_data, regions=parcels)

--- a/examples/plot_int_alignment.py
+++ b/examples/plot_int_alignment.py
@@ -128,7 +128,7 @@ target_test_masked = np.array(masked_imgs)[:, test_index, :]
 
 
 parcels = compute_parcels(
-    niimg=template_train[0], mask=masker, n_parcels=100, n_jobs=5
+    niimg=template_train[0], masker=masker, n_parcels=100, n_jobs=5
 )
 denoiser = PiecewiseAlignment(n_jobs=5)
 denoised_signal = denoiser.fit_transform(X=denoising_data, regions=parcels)

--- a/examples/plot_pairwise_alignment.py
+++ b/examples/plot_pairwise_alignment.py
@@ -94,7 +94,7 @@ target_test = concat_imgs(
 from fmralign.pairwise_alignment import PairwiseAlignment
 
 alignment_estimator = PairwiseAlignment(
-    alignment_method="scaled_orthogonal", n_pieces=150, mask=masker
+    alignment_method="scaled_orthogonal", n_pieces=150, masker=masker
 )
 # Learn alignment operator from subject 1 to subject 2 on training data
 alignment_estimator.fit(source_train, target_train)

--- a/examples/plot_pairwise_roi_alignment.py
+++ b/examples/plot_pairwise_roi_alignment.py
@@ -122,7 +122,7 @@ target_test = concat_imgs(
 from fmralign.pairwise_alignment import PairwiseAlignment
 
 alignment_estimator = PairwiseAlignment(
-    alignment_method="scaled_orthogonal", n_pieces=1, mask=roi_masker
+    alignment_method="scaled_orthogonal", n_pieces=1, masker=roi_masker
 )
 alignment_estimator.fit(source_train, target_train)
 target_pred = alignment_estimator.transform(source_test)

--- a/examples/plot_template_alignment.py
+++ b/examples/plot_template_alignment.py
@@ -101,7 +101,7 @@ from fmralign.template_alignment import TemplateAlignment
 template_estim = TemplateAlignment(
     n_pieces=50,
     alignment_method="scaled_orthogonal",
-    mask=masker,
+    masker=masker,
 )
 template_estim.fit(template_train)
 procrustes_template = template_estim.template

--- a/fmralign/preprocessing.py
+++ b/fmralign/preprocessing.py
@@ -1,6 +1,5 @@
 """Module for preprocessing data before alignment."""
 
-import os
 import warnings
 
 import numpy as np

--- a/fmralign/preprocessing.py
+++ b/fmralign/preprocessing.py
@@ -62,12 +62,19 @@ class ParcellationMasker(BaseEstimator, TransformerMixin):
         nilearn.regions.parcellations
         If 3D Niimg, image used as predefined clustering,
         n_pieces is then ignored.
-    masker : None or :class:`~nilearn.maskers.NiftiMasker` or \
-            :class:`~nilearn.maskers.MultiNiftiMasker`, or \
-            :class:`~nilearn.maskers.SurfaceMasker` , optional
-        A mask to be used on the data. If provided, the mask
-        will be used to extract the data. If None, a mask will
-        be computed automatically with default parameters.
+    masker : None or :class:`~nilearn.surface.SurfaceImage`,\
+           or :class:`nilearn.maskers.NiftiMasker`,\
+           :class:`nilearn.maskers.MultiNiftiMasker` or \
+           :class:`nilearn.maskers.SurfaceMasker`, optional
+        Mask/Masker used for masking the data.
+        If mask image if provided, it will be used in the MultiNiftiMasker or
+        SurfaceMasker (depending on the type of mask image).
+        If an instance of either maskers is provided, then this instance
+        parameters will be used in masking the data by overriding the default
+        masker parameters.
+        If None, mask will be automatically computed by a MultiNiftiMasker
+        with default parameters for Nifti images and no mask will be used for
+        SurfaceImage.
     mask: Niimg-like object, optional (default = None)
         Mask to be used on data.
     smoothing_fwhm: float, optional (default = None)

--- a/fmralign/sparse_pairwise_alignment.py
+++ b/fmralign/sparse_pairwise_alignment.py
@@ -1,7 +1,6 @@
 """Module for sparse pairwise functional alignment."""
 
 import torch
-from joblib import Memory
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
@@ -19,17 +18,7 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
         alignment_method="sparse_uot",
         n_pieces=1,
         clustering="kmeans",
-        mask=None,
-        smoothing_fwhm=None,
-        standardize=False,
-        detrend=False,
-        target_affine=None,
-        target_shape=None,
-        low_pass=None,
-        high_pass=None,
-        t_r=None,
-        memory=Memory(location=None),
-        memory_level=0,
+        masker=None,
         device="cpu",
         n_jobs=1,
         verbose=0,
@@ -54,43 +43,12 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
             nilearn.regions.parcellations
             If 3D Niimg, image used as predefined clustering,
             n_pieces is then ignored.
-        mask: Niimg-like object, instance of NiftiMasker or
-                                MultiNiftiMasker, optional (default = None)
-            Mask to be used on data. If an instance of masker is passed,
-            then its mask will be used. If no mask is given,
-            it will be computed automatically by a MultiNiftiMasker
-            with default parameters.
-        smoothing_fwhm: float, optional (default = None)
-            If smoothing_fwhm is not None, it gives the size in millimeters
-            of the spatial smoothing to apply to the signal.
-        standardize: boolean, optional (default = False)
-            If standardize is True, the time-series are centered and normed:
-            their variance is put to 1 in the time dimension.
-        detrend: boolean, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details
-        target_affine: 3x3 or 4x4 matrix, optional (default = None)
-            This parameter is passed to nilearn.image.resample_img.
-            Please see the related documentation for details.
-        target_shape: 3-tuple of integers, optional (default = None)
-            This parameter is passed to nilearn.image.resample_img.
-            Please see the related documentation for details.
-        low_pass: None or float, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details.
-        high_pass: None or float, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details.
-        t_r: float, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details.
-        memory: instance of joblib.Memory or string (default = None)
-            Used to cache the masking process and results of algorithms.
-            By default, no caching is done. If a string is given, it is the
-            path to the caching directory.
-        memory_level: integer, optional (default = None)
-            Rough estimator of the amount of memory used by caching.
-            Higher value means more memory for caching.
+        masker : None or :class:`~nilearn.maskers.NiftiMasker` or \
+                :class:`~nilearn.maskers.MultiNiftiMasker`, or \
+                :class:`~nilearn.maskers.SurfaceMasker` , optional
+            A mask to be used on the data. If provided, the mask
+            will be used to extract the data. If None, a mask will
+            be computed automatically with default parameters.
         device: string, optional (default = 'cpu')
             Device on which the computation will be done. If 'cuda', the
             computation will be done on the GPU if available.
@@ -103,17 +61,7 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
         self.n_pieces = n_pieces
         self.alignment_method = alignment_method
         self.clustering = clustering
-        self.mask = mask
-        self.smoothing_fwhm = smoothing_fwhm
-        self.standardize = standardize
-        self.detrend = detrend
-        self.low_pass = low_pass
-        self.high_pass = high_pass
-        self.t_r = t_r
-        self.target_affine = target_affine
-        self.target_shape = target_shape
-        self.memory = memory
-        self.memory_level = memory_level
+        self.masker = masker
         self.n_jobs = n_jobs
         self.device = device
         self.verbose = verbose
@@ -137,24 +85,13 @@ class SparsePairwiseAlignment(BaseEstimator, TransformerMixin):
         self.parcel_masker = ParcellationMasker(
             n_pieces=self.n_pieces,
             clustering=self.clustering,
-            mask=self.mask,
-            smoothing_fwhm=self.smoothing_fwhm,
-            standardize=self.standardize,
-            detrend=self.detrend,
-            low_pass=self.low_pass,
-            high_pass=self.high_pass,
-            t_r=self.t_r,
-            target_affine=self.target_affine,
-            target_shape=self.target_shape,
-            memory=self.memory,
-            memory_level=self.memory_level,
+            masker=self.masker,
             n_jobs=self.n_jobs,
             verbose=self.verbose,
         )
 
         self.parcel_masker.fit([X, Y])
-        self.masker = self.parcel_masker.masker_
-        self.mask = self.parcel_masker.masker_.mask_img_
+        self.masker = self.parcel_masker.masker
         self.labels_ = self.parcel_masker.labels
         self.n_pieces = self.parcel_masker.n_pieces
 

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -1,7 +1,6 @@
 """Module for sparse template alignment."""
 
 import torch
-from joblib import Memory
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 

--- a/fmralign/sparse_template_alignment.py
+++ b/fmralign/sparse_template_alignment.py
@@ -145,17 +145,7 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
         scale_template=False,
         n_iter=2,
         save_template=None,
-        mask=None,
-        smoothing_fwhm=None,
-        standardize=False,
-        detrend=None,
-        target_affine=None,
-        target_shape=None,
-        low_pass=None,
-        high_pass=None,
-        t_r=None,
-        memory=Memory(location=None),
-        memory_level=0,
+        masker=None,
         device="cpu",
         n_jobs=1,
         verbose=0,
@@ -187,42 +177,6 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
            the template is simply the mean of the input images.
         save_template: None or string(optional)
             If not None, path to which the template will be saved.
-        mask: Niimg-like object, instance of NiftiMasker or
-                                MultiNiftiMasker, optional (default = None)
-            Mask to be used on data. If an instance of masker is passed, then its
-            mask will be used. If no mask is given, it will be computed
-            automatically by a MultiNiftiMasker with default parameters.
-        smoothing_fwhm: float, optional (default = None)
-            If smoothing_fwhm is not None, it gives the size in millimeters
-            of the spatial smoothing to apply to the signal.
-        standardize: boolean, optional (default = None)
-            If standardize is True, the time-series are centered and normed:
-            their variance is put to 1 in the time dimension.
-        detrend: boolean, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details
-        target_affine: 3x3 or 4x4 matrix, optional (default = None)
-            This parameter is passed to nilearn.image.resample_img.
-            Please see the related documentation for details.
-        target_shape: 3-tuple of integers, optional (default = None)
-            This parameter is passed to nilearn.image.resample_img.
-            Please see the related documentation for details.
-        low_pass: None or float, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details.
-        high_pass: None or float, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details.
-        t_r: float, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details.
-        memory: instance of joblib.Memory or string (default = None)
-            Used to cache the masking process and results of algorithms.
-            By default, no caching is done. If a string is given, it is the
-            path to the caching directory.
-        memory_level: integer, optional (default = None)
-            Rough estimator of the amount of memory used by caching.
-            Higher value means more memory for caching.
         device: string, optional (default = 'cpu')
             Device on which the computation will be done. If 'cuda', the
             computation will be done on the GPU if available.
@@ -241,18 +195,8 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
         self.n_iter = n_iter
         self.scale_template = scale_template
         self.save_template = save_template
-        self.mask = mask
-        self.smoothing_fwhm = smoothing_fwhm
-        self.standardize = standardize
-        self.detrend = detrend
-        self.target_affine = target_affine
-        self.target_shape = target_shape
-        self.low_pass = low_pass
-        self.high_pass = high_pass
-        self.t_r = t_r
+        self.masker = masker
         self.device = device
-        self.memory = memory
-        self.memory_level = memory_level
         self.n_jobs = n_jobs
         self.verbose = verbose
         self.kwargs = kwargs
@@ -281,24 +225,13 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
         self.parcel_masker = ParcellationMasker(
             n_pieces=self.n_pieces,
             clustering=self.clustering,
-            mask=self.mask,
-            smoothing_fwhm=self.smoothing_fwhm,
-            standardize=self.standardize,
-            detrend=self.detrend,
-            low_pass=self.low_pass,
-            high_pass=self.high_pass,
-            t_r=self.t_r,
-            target_affine=self.target_affine,
-            target_shape=self.target_shape,
-            memory=self.memory,
-            memory_level=self.memory_level,
+            masker=self.masker,
             n_jobs=self.n_jobs,
             verbose=self.verbose,
         )
 
         self.parcel_masker.fit(imgs)
-        self.masker = self.parcel_masker.masker_
-        self.mask = self.parcel_masker.masker_.mask_img_
+        self.masker = self.parcel_masker.masker
         self.labels_ = self.parcel_masker.labels
         self.n_pieces = self.parcel_masker.n_pieces
 
@@ -361,17 +294,7 @@ class SparseTemplateAlignment(BaseEstimator, TransformerMixin):
                 n_pieces=self.n_pieces,
                 alignment_method=self.alignment_method,
                 clustering=self.parcel_masker.get_parcellation_img(),
-                mask=self.masker,
-                smoothing_fwhm=self.smoothing_fwhm,
-                standardize=self.standardize,
-                detrend=self.detrend,
-                target_affine=self.target_affine,
-                target_shape=self.target_shape,
-                low_pass=self.low_pass,
-                high_pass=self.high_pass,
-                t_r=self.t_r,
-                memory=self.memory,
-                memory_level=self.memory_level,
+                masker=self.masker,
                 n_jobs=self.n_jobs,
                 verbose=self.verbose,
             )

--- a/fmralign/srm.py
+++ b/fmralign/srm.py
@@ -99,15 +99,7 @@ class PiecewiseModel(BaseEstimator, TransformerMixin):
         srm,
         n_pieces=1,
         clustering="kmeans",
-        mask=None,
-        smoothing_fwhm=None,
-        standardize=False,
-        detrend=None,
-        target_affine=None,
-        target_shape=None,
-        low_pass=None,
-        high_pass=None,
-        t_r=None,
+        masker=None,
         n_jobs=1,
         verbose=0,
         reshape=True,
@@ -127,35 +119,12 @@ class PiecewiseModel(BaseEstimator, TransformerMixin):
             passed to nilearn.regions.parcellations
             If 3D Niimg, image used as predefined clustering,
             n_pieces is then ignored.
-        mask: Niimg-like object, instance of NiftiMasker or
-                                MultiNiftiMasker, optional (default = None)
-            Mask to be used on data. If an instance of masker is passed, then its
-            mask will be used. If no mask is given, it will be computed
-            automatically by a MultiNiftiMasker with default parameters.
-        smoothing_fwhm: float, optional (default = None)
-            If smoothing_fwhm is not None, it gives the size in millimeters
-            of the spatial smoothing to apply to the signal.
-        standardize: boolean, optional (default = None)
-            If standardize is True, the time-series are centered and normed:
-            their variance is put to 1 in the time dimension.
-        detrend: boolean, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details
-        target_affine: 3x3 or 4x4 matrix, optional (default = None)
-            This parameter is passed to nilearn.image.resample_img.
-            Please see the related documentation for details.
-        target_shape: 3-tuple of integers, optional (default = None)
-            This parameter is passed to nilearn.image.resample_img.
-            Please see the related documentation for details.
-        low_pass: None or float, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details.
-        high_pass: None or float, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details.
-        t_r: float, optional (default = None)
-            This parameter is passed to nilearn.signal.clean.
-            Please see the related documentation for details.
+        masker : None or :class:`~nilearn.maskers.NiftiMasker` or \
+                :class:`~nilearn.maskers.MultiNiftiMasker`, or \
+                :class:`~nilearn.maskers.SurfaceMasker` , optional
+            A mask to be used on the data. If provided, the mask
+            will be used to extract the data. If None, a mask will
+            be computed automatically with default parameters.
         n_jobs: integer, optional (default = 1)
             The number of CPUs to use to do the computation. -1 means
             'all CPUs', -2 'all CPUs but one', and so on.
@@ -165,18 +134,8 @@ class PiecewiseModel(BaseEstimator, TransformerMixin):
         self.srm = srm
         self.n_pieces = n_pieces
         self.clustering = clustering
-        self.mask = mask
-        self.smoothing_fwhm = smoothing_fwhm
-        self.standardize = standardize
-        self.detrend = detrend
-        self.target_affine = target_affine
-        self.target_shape = target_shape
-        self.low_pass = low_pass
-        self.high_pass = high_pass
-        self.t_r = t_r
+        self.masker = masker
         self.n_jobs = n_jobs
-        self.memory = None
-        self.memory_level = 0
         self.verbose = verbose
         self.reshape = reshape
 
@@ -203,23 +162,14 @@ class PiecewiseModel(BaseEstimator, TransformerMixin):
         self.parcel_masker = ParcellationMasker(
             n_pieces=self.n_pieces,
             clustering=self.clustering,
-            mask=self.mask,
-            smoothing_fwhm=self.smoothing_fwhm,
-            standardize=self.standardize,
-            detrend=self.detrend,
-            low_pass=self.low_pass,
-            high_pass=self.high_pass,
-            t_r=self.t_r,
-            target_affine=self.target_affine,
-            target_shape=self.target_shape,
-            memory=self.memory,
-            memory_level=self.memory_level,
+            masker=self.masker,
+            memory=None,
+            memory_level=0,
             n_jobs=self.n_jobs,
             verbose=self.verbose,
         )
         parceled_data = self.parcel_masker.fit_transform(imgs)
-        self.masker_ = self.parcel_masker.masker_
-        self.mask = self.parcel_masker.masker_.mask_img_
+        self.masker = self.parcel_masker.masker
         self.labels_ = self.parcel_masker.labels
         self.n_pieces = self.parcel_masker.n_pieces
 
@@ -310,7 +260,7 @@ class PiecewiseModel(BaseEstimator, TransformerMixin):
                 )
 
         basis_imgs = [
-            self.masker_.inverse_transform(full_basis.T)
+            self.masker.inverse_transform(full_basis.T)
             for full_basis in full_basis_list
         ]
         return basis_imgs

--- a/fmralign/template_alignment.py
+++ b/fmralign/template_alignment.py
@@ -7,7 +7,7 @@ Uses functional alignment on Niimgs and predicts new subjects' unseen images.
 # License: simplified BSD
 
 import numpy as np
-from joblib import Memory, Parallel, delayed
+from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 

--- a/fmralign/tests/test_sparse_template_alignment.py
+++ b/fmralign/tests/test_sparse_template_alignment.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 from nibabel.nifti1 import Nifti1Image
+from nilearn.maskers import NiftiMasker
 
 from fmralign.alignment_methods import POTAlignment, SparseUOT
 from fmralign.sparse_template_alignment import (
@@ -128,13 +129,14 @@ def test_parcellation_before_fit():
 def test_consistency_with_dense_templates():
     """Test that SparseTemplateAlignment outputs\n
     consistent templates with TemplateAlignment"""
-    img1, mask = random_niimg((8, 7, 6, 20))
+    img1, mask_img = random_niimg((8, 7, 6, 20))
     img2, _ = random_niimg((8, 7, 6, 20))
     img3, _ = random_niimg((8, 7, 6, 20))
+    masker = NiftiMasker(mask_img=mask_img).fit()
 
     dense_algo = TemplateAlignment(
         n_pieces=3,
-        mask=mask,
+        masker=masker,
         alignment_method=POTAlignment(),
     )
     dense_algo.fit([img1, img2, img3])
@@ -144,7 +146,7 @@ def test_consistency_with_dense_templates():
     masker = dense_algo.masker
     sparse_algo = SparseTemplateAlignment(
         clustering=clustering_img,
-        mask=masker,
+        masker=masker,
     )
     sparse_algo.fit([img1, img2, img3])
 

--- a/fmralign/tests/test_srm.py
+++ b/fmralign/tests/test_srm.py
@@ -70,7 +70,7 @@ def test_output_no_clustering(algo):
             "identity",
             n_pieces=n_pieces,
             clustering="kmeans",
-            mask=masker,
+            masker=masker,
             n_jobs=-1,
         )
         algo = Identity()
@@ -80,7 +80,7 @@ def test_output_no_clustering(algo):
             algo,
             n_pieces=n_pieces,
             clustering="kmeans",
-            mask=masker,
+            masker=masker,
             n_jobs=-1,
         )
     psrm.fit(list(train_data.values())[:-1])
@@ -145,10 +145,12 @@ def test_algo_each_piece(algo):
     cluster = np.array([1, 1, 1, 1, 2, 2, 2, 2])
     niimg_cluster = masker.inverse_transform(cluster)
     if algo == "identity":
-        srm = PiecewiseModel("identity", mask=masker, clustering=niimg_cluster)
+        srm = PiecewiseModel(
+            "identity", masker=masker, clustering=niimg_cluster
+        )
         algo = Identity()
     else:
-        srm = PiecewiseModel(algo, clustering=niimg_cluster, mask=masker)
+        srm = PiecewiseModel(algo, clustering=niimg_cluster, masker=masker)
     S1 = np.array(
         [
             clone(algo).fit_transform(
@@ -181,10 +183,12 @@ def test_wrongshape(algo):
     cluster = np.array([1] * 8 + [2] * 56)
     niimg_cluster = masker.inverse_transform(cluster)
     if algo == "identity":
-        srm = PiecewiseModel("identity", mask=masker, clustering=niimg_cluster)
+        srm = PiecewiseModel(
+            "identity", masker=masker, clustering=niimg_cluster
+        )
         algo = Identity()
     else:
-        srm = PiecewiseModel(algo, clustering=niimg_cluster, mask=masker)
+        srm = PiecewiseModel(algo, clustering=niimg_cluster, masker=masker)
         S1 = np.array(
             [
                 clone(algo).fit_transform(

--- a/fmralign/tests/test_template_alignment.py
+++ b/fmralign/tests/test_template_alignment.py
@@ -44,7 +44,7 @@ def test_reconstruct_template():
     parcel_masker = ParcellationMasker(n_pieces=n_pieces)
     subjects_parcels = parcel_masker.fit_transform(imgs)
     parcels_subjects = _index_by_parcel(subjects_parcels)
-    masker = parcel_masker.masker_
+    masker = parcel_masker.masker
     labels = parcel_masker.labels
 
     fit = [
@@ -119,21 +119,16 @@ def test_template_identity():
     subs = [sub_1, sub_2, sub_3]
 
     # test different fit() accept list of list of 3D Niimgs as input.
-    algo = TemplateAlignment(alignment_method="identity", mask=masker)
+    algo = TemplateAlignment(alignment_method="identity", masker=masker)
     algo.fit([concat_imgs(n * [im])] * 3)
     # test template
     assert_array_almost_equal(sub_1.get_fdata(), algo.template.get_fdata())
 
     # test fit() transform() with 4D Niimgs input for several params set
     args_list = [
-        {"alignment_method": "identity", "mask": masker},
-        {"alignment_method": "identity", "mask": masker, "n_jobs": 2},
-        {"alignment_method": "identity", "n_pieces": 3, "mask": masker},
-        {
-            "alignment_method": "identity",
-            "n_pieces": 3,
-            "mask": masker,
-        },
+        {"alignment_method": "identity", "masker": masker},
+        {"alignment_method": "identity", "masker": masker, "n_jobs": 2},
+        {"alignment_method": "identity", "n_pieces": 3, "masker": masker},
     ]
 
     for args in args_list:
@@ -171,7 +166,7 @@ def test_template_diagonal():
     subs = [sub_1, sub_2, sub_3]
 
     # Test without subject_index
-    algo = TemplateAlignment(alignment_method="diagonal", mask=masker)
+    algo = TemplateAlignment(alignment_method="diagonal", masker=masker)
     algo.fit(subs)
     predicted_imgs = algo.transform(sub_1, subject_index=None)
     assert_array_almost_equal(
@@ -215,7 +210,7 @@ def test_template_closer_to_target():
         algo = TemplateAlignment(
             alignment_method=alignment_method,
             n_pieces=3,
-            mask=masker,
+            masker=masker,
         )
         # Learn template
         algo.fit(subs)

--- a/fmralign/tests/utils.py
+++ b/fmralign/tests/utils.py
@@ -106,24 +106,6 @@ def random_niimg(shape):
     return im, mask_img
 
 
-def assert_model_align_better_than_identity(algo, img1, img2, mask=None):
-    """
-    Tests that the given algorithm aligns better than identity.
-    Proficiency is measured through r2 score.
-    """
-    algo.fit(img1, img2)
-    im_test = algo.transform(img1)
-    masker = NiftiMasker(mask)
-    masker.fit()
-    identity_baseline_score = zero_mean_coefficient_determination(
-        masker.transform(img2), masker.transform(img1)
-    )
-    algo_score = zero_mean_coefficient_determination(
-        masker.transform(img2), masker.transform(im_test)
-    )
-    assert algo_score >= identity_baseline_score
-
-
 def sample_parceled_data(n_pieces=1):
     """Create sample data for testing"""
     img, mask_img = random_niimg((8, 7, 6, 20))

--- a/fmralign/tests/utils.py
+++ b/fmralign/tests/utils.py
@@ -83,15 +83,13 @@ def assert_class_align_better_than_identity(algo, X, Y):
     assert algo_score >= identity_baseline_score
 
 
-def assert_algo_transform_almost_exactly(algo, img1, img2, mask=None):
+def assert_algo_transform_almost_exactly(algo, img1, img2, masker):
     """
     Tests that the given algorithm manages to transform (almost exactly)
     Nifti image img1 into Nifti Image img2.
     """
     algo.fit(img1, img2)
     imtest = algo.transform(img1)
-    masker = NiftiMasker(mask_img=mask)
-    masker.fit()
     assert_array_almost_equal(
         masker.transform(img2), masker.transform(imtest), decimal=6
     )


### PR DESCRIPTION
Fixes #128. Masker handling is now offloaded to nilearn. The user can now pass in an already initialized nilearn masker (fitted or not) or a new one will be computed with default parameters.