### PR TITLE
[DOC] Add pairwise surface alignment example

### DIFF
--- a/examples/plot_surf_alignment.py
+++ b/examples/plot_surf_alignment.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+# %%
+"""
+Pairwise functional alignment.
+==============================
+
+In this tutorial, we show how to better predict new contrasts for a target
+subject using source subject corresponding contrasts and data in common.
+
+We mostly rely on python common packages and on nilearn to handle functional
+data in a clean fashion.
+
+
+To run this example, you must launch IPython via ``ipython
+--matplotlib`` in a terminal, or use ``jupyter-notebook``.
+"""
+###############################################################################
+# Retrieve the data
+# -----------------
+# In this example we use the IBC dataset, which include a large number of
+# different contrasts maps for 12 subjects. We download the images for
+# subjects sub-01 and sub-02 (or retrieve them if they were already downloaded)
+# Files is the list of paths for each subjects.
+# df is a dataframe with metadata about each of them.
+# mask is an appropriate nifti image to select the data.
+#
+
+from fmralign.fetch_example_data import fetch_ibc_subjects_contrasts
+
+files, df, _ = fetch_ibc_subjects_contrasts(["sub-01", "sub-02"])
+
+
+###############################################################################
+# Project the data on the fsaverage5 surface
+# ------------------------------------------
+# We project the data on the fsaverage5 surface, using the fsaverage5
+# surface template.
+
+from nilearn.datasets import load_fsaverage
+from nilearn.surface import SurfaceImage
+
+fsaverage_meshes = load_fsaverage()
+
+
+def project_to_surface(img):
+    """Util function for loading and projecting volumetric images."""
+    surface_image = SurfaceImage.from_volume(
+        mesh=fsaverage_meshes["pial"],
+        volume_img=img,
+    )
+    return surface_image
+
+
+from nilearn.image import concat_imgs
+
+source_train = concat_imgs(
+    df[df.subject == "sub-01"][df.acquisition == "ap"].path.values
+)
+target_train = concat_imgs(
+    df[df.subject == "sub-02"][df.acquisition == "ap"].path.values
+)
+
+surf_source_train = project_to_surface(source_train)
+surf_target_train = project_to_surface(target_train)
+
+
+###############################################################################
+# Plot the source and target data
+# -------------------------------
+# We plot the source and target data on the fsaverage5 surface.
+from fmralign.pairwise_alignment import PairwiseAlignment
+
+alignment_estimator = PairwiseAlignment(
+    alignment_method="scaled_orthogonal",
+    n_pieces=100,
+    clustering="ward",
+    verbose=10,
+)
+# Learn alignment operator from subject 1 to subject 2 on training data
+alignment_estimator.fit(surf_source_train, surf_target_train)
+
+
+###############################################################################
+# Plot the computed parcellation
+# ------------------------------
+_, clustering_img = alignment_estimator.get_parcellation()
+
+# %%
+from nilearn import plotting
+
+plotting.plot_surf_roi(
+    surf_mesh=fsaverage_meshes["pial"],
+    roi_map=clustering_img,
+    hemi="left",
+    view="lateral",
+    title="Ward parcellation on the left hemisphere",
+)
+plotting.show()
+
+# %%
+# Let's now align a left-out audio contrast from sub-01 to sub-02.
+
+surf_audio_source = project_to_surface(
+    df[
+        (df.subject == "sub-01")
+        & (df.condition == "audio_sentence")
+        & (df.acquisition == "pa")
+    ].path.values
+)
+
+surf_audio_target = project_to_surface(
+    df[
+        (df.subject == "sub-02")
+        & (df.condition == "audio_sentence")
+        & (df.acquisition == "pa")
+    ].path.values
+)
+
+surf_aligned = alignment_estimator.transform(surf_audio_source)
+
+
+# %%
+from copy import deepcopy
+
+
+def interpolate_surf_image(surf_img1, surf_img2, alpha=0.5):
+    """Interpolate two surface images."""
+    # Create a new surface image with the same mesh as the input
+    surf_img_interpolated = deepcopy(surf_img1)
+    # Interpolate the data
+    for hemi in ["left", "right"]:
+        surf_img_interpolated.data.parts[hemi] = surf_img1.data.parts[
+            hemi
+        ] * alpha + surf_img2.data.parts[hemi] * (1 - alpha)
+    return surf_img_interpolated
+
+
+interpolate_surf_image(surf_audio_source, surf_aligned, alpha=0.5)
+# %%
+for alpha in [0.1, 0.3, 0.5, 0.7, 0.9]:
+    surf_interpolated = interpolate_surf_image(
+        surf_audio_source, surf_aligned, alpha=alpha
+    )
+    plotting.plot_surf_stat_map(
+        surf_mesh=fsaverage_meshes["pial"],
+        stat_map=surf_interpolated,
+        hemi="left",
+        view="lateral",
+        title=f"Interpolated audio sentence alpha={alpha}",
+        colorbar=True,
+    )
+    plotting.show()
+
+# %%
+import matplotlib.pyplot as plt
+from IPython.display import HTML
+from matplotlib.animation import FuncAnimation
+from nilearn import plotting
+from nilearn.datasets import load_fsaverage_data
+
+fsaverage_sulcal = load_fsaverage_data(
+    mesh="fsaverage5",
+    data_type="sulcal",
+    mesh_type="inflated",
+)
+# %%
+# Create figure
+fig = plt.figure(figsize=(10, 8))
+
+
+# Define a function to update the figure for each frame
+def update(frame):
+    plt.clf()
+
+    if frame <= 9:
+        # Interpolation frames (0-9)
+        alpha = frame / 9
+        surf_interpolated = interpolate_surf_image(
+            surf_audio_source, surf_aligned, alpha=alpha
+        )
+        plotting.plot_surf_stat_map(
+            surf_mesh=fsaverage_meshes["pial"],
+            stat_map=surf_interpolated,
+            bg_map=fsaverage_sulcal,
+            hemi="left",
+            view="lateral",
+            colorbar=True,
+            figure=fig,
+            alpha=0.5,
+            bg_on_data=True,
+            vmax=3,
+            vmin=-3,
+            cmap="coolwarm",
+        )
+        plt.suptitle(
+            f"Interpolated audio sentence alpha={alpha:.2f}", fontsize=16
+        )
+    else:
+        # Target image (frame 10)
+        plotting.plot_surf_stat_map(
+            surf_mesh=fsaverage_meshes["pial"],
+            stat_map=surf_audio_target,
+            bg_map=fsaverage_sulcal,
+            hemi="left",
+            view="lateral",
+            colorbar=True,
+            figure=fig,
+            alpha=0.5,
+            bg_on_data=True,
+            vmax=3,
+            vmin=-3,
+            cmap="coolwarm",
+        )
+        plt.suptitle("Target image", fontsize=16)
+
+    return [fig]
+
+
+# Create animation with 11 frames and 200ms interval
+anim = FuncAnimation(fig, update, frames=range(11), interval=300, blit=True)
+
+# Display in notebook
+HTML(anim.to_jshtml())


### PR DESCRIPTION
This PR adds an example of Procrustes alignment on the fsaverage5 surface using Ward clustering. An interactive matplotlib animation is added at the end of the notebook to progressively watch the individual idiosyncrasies get smoothed out by the alignment process.