### PR TITLE
[ENH] Add saving and loading utilities for alignment estimators

### DIFF
--- a/examples/plot_pairwise_alignment.py
+++ b/examples/plot_pairwise_alignment.py
@@ -3,7 +3,7 @@
 """
 Pairwise functional alignment.
 ==============================
-
+This is a comment
 In this tutorial, we show how to better predict new contrasts for a target
 subject using source subject corresponding contrasts and data in common.
 

--- a/fmralign/_utils.py
+++ b/fmralign/_utils.py
@@ -10,6 +10,10 @@ from nilearn.image import new_img_like, smooth_img
 from nilearn.masking import apply_mask_fmri, intersect_masks
 from nilearn.regions.parcellations import Parcellations
 from nilearn.surface import SurfaceImage
+from pathlib import Path
+import joblib
+import datetime
+from sklearn.exceptions import NotFittedError
 
 
 class ParceledData:
@@ -315,3 +319,80 @@ def _sparse_cluster_matrix(arr):
     ).coalesce()
 
     return sparse_matrix
+
+
+def save_alignment(alignment_estimator, output_path):
+    """Save the alignment estimator object to a file.
+
+    Parameters
+    ----------
+    alignment_estimator : :obj:`PairwiseAlignment` or :obj:`TemplateAlignment`
+        The alignment estimator object to be saved.
+        It should be an instance of either `PairwiseAlignment` or
+        `TemplateAlignment`.
+        The object should have been fitted before saving.
+    output_path : str or Path
+        Path to the file or directory where the model will be saved.
+        If a directory is provided, the model will be saved with a
+        timestamped filename in that directory.
+        If a file is provided, the model will be saved with that filename.
+
+    Raises
+    ------
+    NotFittedError
+        If the alignment estimator has not been fitted yet.
+    ValueError
+        If the output path is not a valid file or directory.
+    """
+    if not hasattr(alignment_estimator, "fit_"):
+        raise NotFittedError(
+            "This instance has not been fitted yet. "
+            "Please call 'fit' before 'save'."
+        )
+
+    output_path = Path(output_path)
+
+    if output_path.is_dir():
+        output_path.mkdir(parents=True, exist_ok=True)
+        suffix = f"alignment_estimator_{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.pkl"
+        joblib.dump(alignment_estimator, output_path / suffix)
+
+    else:
+        joblib.dump(alignment_estimator, output_path)
+
+
+def load_alignment(input_path):
+    """Load an alignment estimator object from a file.
+
+    Parameters
+    ----------
+    input_path : str or Path
+        Path to the file or directory from which the model will be loaded.
+        If a directory is provided, the latest .pkl file in that directory
+        will be loaded.
+
+    Returns
+    -------
+    alignment_estimator : :obj:`PairwiseAlignment` or :obj:`TemplateAlignment`
+        The loaded alignment estimator object.
+        It will be an instance of either `PairwiseAlignment` or
+        `TemplateAlignment`, depending on what was saved.
+
+    Raises
+    ------
+    ValueError
+        If no .pkl files are found in the directory or if the input path is not
+        a valid file or directory.
+    """
+    input_path = Path(input_path)
+
+    if input_path.is_dir():
+        # If it's a directory, look for the latest .pkl file
+        pkl_files = list(input_path.glob("*.pkl"))
+        if not pkl_files:
+            raise ValueError(
+                f"No .pkl files found in the directory: {input_path}"
+            )
+        input_path = max(pkl_files, key=lambda x: x.stat().st_mtime)
+
+    return joblib.load(input_path)


### PR DESCRIPTION
This short PR provides two new utilities for saving and loading fitted estimators. Usage is as such:

```python
from fmralign._utils import save_alignment, load_alignment

estimator = PairwiseAlignment().fit(X, Y)
save_alignment(estimator, "save_dir")
loaded_estimator = load_alignment("save_dir")
```